### PR TITLE
FUSETOOLS-2378 - Rename archetype catalog

### DIFF
--- a/editor/plugins/org.fusesource.ide.branding/OSGI-INF/l10n/bundle.properties
+++ b/editor/plugins/org.fusesource.ide.branding/OSGI-INF/l10n/bundle.properties
@@ -26,6 +26,6 @@ project.wizard.project.description = Create a new Fuse Project using the Maven b
 
 rider.preferences.label=Fuse Tooling
 
-remote.description = Fuse Tooling Remote Archetype Catalog
+remote.description = Fuse 6.2.1 and before Remote Archetype Catalog
 Bundle-Vendor = JBoss by Red Hat
 Bundle-Name = Fuse Branding Plugin


### PR DESCRIPTION
the provided archetype catalog has been used up until Fuse 6.2.1
version, it is now on normal redhat GA repository