### PR TITLE
use jbtis.version = 4.5.0.AM1-SNAPSHOT in...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 
 		<!-- JBoss Tools Integration Stack version -->
-		<jbtis.version>4.4.3.CR1-SNAPSHOT</jbtis.version>
+		<jbtis.version>4.5.0.AM1-SNAPSHOT</jbtis.version>
 		<jbtis.classifier>base</jbtis.classifier> <!-- base-ea -->
 
 		<!-- Tycho versions -->


### PR DESCRIPTION
use jbtis.version = 4.5.0.AM1-SNAPSHOT in Oxygen-based 10.x branch

Signed-off-by: nickboldt <nboldt@redhat.com>