### PR TITLE
override the default surefire timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,9 @@
 		<tychoVersion>0.26.0</tychoVersion>
 		<tychoExtrasVersion>${tychoVersion}</tychoExtrasVersion>
 
+		<!-- increase the timeout for tests as they might need longer for downloads -->
+		<surefire.timeout>5400</surefire.timeout>
+
 		<!-- fuse tooling related -->
 		<tycho.scmUrl>scm:git:https://github.com/fusesource/fuseide.git</tycho.scmUrl>
 		<forge-project-id>ide</forge-project-id>


### PR DESCRIPTION
rebased version of https://github.com/jbosstools/jbosstools-fuse/pull/950 as the 4.4.3.CR1-SNAPSHOT seems to have vanished