### PR TITLE
FUSETOOLS-2388 - workaround to play blueprint test with Camel

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint/pom.xml
@@ -126,6 +126,12 @@
 			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-test-blueprint</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>org.apache.felix.fileinstall</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-blueprint/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-blueprint/pom.xml
@@ -78,6 +78,12 @@
 			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-test-blueprint</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>org.apache.felix.fileinstall</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 	<repositories>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/pom.xml
@@ -59,6 +59,12 @@
 			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-test-blueprint</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>org.apache.felix.fileinstall</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 	<repositories>

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForCBRIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForCBRIT.java
@@ -39,19 +39,16 @@ public class FuseIntegrationProjectCreatorRunnableForCBRIT  extends FuseIntegrat
 	@Test
 	public void testCBRBluePrintCreation() throws Exception {
 		assumeFalse("Blueprint with 2.15 redhat version is not working, see https://issues.jboss.org/browse/FUSETOOLS-1986", camelVersion.startsWith("2.15"));
-		assumeFalse("2.18.x redhat version is not working, see https://issues.apache.org/jira/browse/CAMEL-10602", camelVersion.startsWith("2.18"));
 		testProjectCreation("-CBRBlueprint-"+camelVersion, CamelDSLType.BLUEPRINT, "src/main/resources/OSGI-INF/blueprint/blueprint.xml", null);
 	}
 		
 	@Test
 	public void testCBRSpringCreation() throws Exception {
-		assumeFalse("2.18.x redhat version is not working, see https://issues.apache.org/jira/browse/CAMEL-10602", camelVersion.startsWith("2.18"));
 		testProjectCreation("-CBRSpring-"+camelVersion, CamelDSLType.SPRING, "src/main/resources/META-INF/spring/camel-context.xml", null);
 	}
 	
 	@Test
 	public void testCBRJavaProjectCreation() throws Exception {
-		assumeFalse("2.18.x redhat version is not working, see https://issues.apache.org/jira/browse/CAMEL-10602", camelVersion.startsWith("2.18"));
 		testProjectCreation("-CBRJavaProject-"+camelVersion, CamelDSLType.JAVA, "src/main/java/com/mycompany/camel/CamelRoute.java", null);
 	}
 	


### PR DESCRIPTION
2.18.1.redhat-000015

- exclude fileinstall as a workaround
- reactivate CBR test with 2.18 version