### PR TITLE
FUSETOOLS-2392 experiment with using better...

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint/pom.xml
@@ -35,7 +35,7 @@
 		<repository>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -62,7 +62,7 @@
 		<pluginRepository>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java/pom.xml
@@ -68,7 +68,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</repository>
 		<repository>
 			<releases>
@@ -94,7 +94,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</pluginRepository>
 		<pluginRepository>
 			<releases>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring/pom.xml
@@ -34,7 +34,7 @@
 		<repository>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -61,7 +61,7 @@
 		<pluginRepository>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-blueprint/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-blueprint/pom.xml
@@ -168,7 +168,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</repository>
 		<repository>
 			<releases>
@@ -194,7 +194,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</pluginRepository>
 		<pluginRepository>
 			<releases>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java/pom.xml
@@ -151,7 +151,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</repository>
 		<repository>
 			<releases>
@@ -177,7 +177,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</pluginRepository>
 		<pluginRepository>
 			<releases>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring/pom.xml
@@ -178,7 +178,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</repository>
 		<repository>
 			<releases>
@@ -204,7 +204,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</pluginRepository>
 		<pluginRepository>
 			<releases>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-blueprint/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-blueprint/pom.xml
@@ -184,7 +184,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</repository>
 	</repositories>
 	<pluginRepositories>
@@ -198,7 +198,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-java/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-java/pom.xml
@@ -149,7 +149,7 @@
       </snapshots>
       <id>fuse-public-repository</id>
       <name>FuseSource Community Release Repository</name>
-      <url>https://repo.fusesource.com/nexus/content/groups/public</url>
+      <url>${fusesourceNexusCommunity}</url>
     </repository>
 	<repository>
 	  <id>red-hat-ga-repository</id>
@@ -175,7 +175,7 @@
       </snapshots>
       <id>fuse-public-repository</id>
       <name>FuseSource Community Release Repository</name>
-      <url>https://repo.fusesource.com/nexus/content/groups/public</url>
+      <url>${fusesourceNexusCommunity}</url>
     </pluginRepository>
 	<pluginRepository>
 	  <id>red-hat-ga-repository</id>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-spring/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-spring/pom.xml
@@ -174,7 +174,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</repository>
 	</repositories>
 	<pluginRepositories>
@@ -188,7 +188,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</pluginRepository>
 	</pluginRepositories>
 	<build>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-cdi/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-cdi/pom.xml
@@ -241,7 +241,7 @@
         </repository>
         <repository>
             <id>fusesource-release-repository</id>
-            <url>https://repo.fusesource.com/nexus/content/groups/public/</url>
+            <url>${fusesourceNexusCommunity}/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -251,7 +251,7 @@
         </repository>
         <repository>
             <id>fusesource-earlyaccess-repository</id>
-            <url>https://repo.fusesource.com/nexus/content/groups/ea</url>
+            <url>https://${jbossNexus}/nexus/content/groups/ea</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -293,7 +293,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>fusesource-release-plugin-repository</id>
-            <url>https://repo.fusesource.com/nexus/content/groups/public/</url>
+            <url>${fusesourceNexusCommunity}/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -303,7 +303,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>fusesource-earlyaccess-plugin-repository</id>
-            <url>https://repo.fusesource.com/nexus/content/groups/ea</url>
+            <url>https://${jbossNexus}/nexus/content/groups/ea</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-spring/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-spring/pom.xml
@@ -189,7 +189,7 @@
         </repository>
         <repository>
             <id>fusesource-release-repository</id>
-            <url>https://repo.fusesource.com/nexus/content/groups/public/</url>
+            <url>${fusesourceNexusCommunity}/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -199,7 +199,7 @@
         </repository>
         <repository>
             <id>fusesource-earlyaccess-repository</id>
-            <url>https://repo.fusesource.com/nexus/content/groups/ea</url>
+            <url>https://${jbossNexus}/nexus/content/groups/ea</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -231,7 +231,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>fusesource-release-plugin-repository</id>
-            <url>https://repo.fusesource.com/nexus/content/groups/public/</url>
+            <url>${fusesourceNexusCommunity}/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -241,7 +241,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>fusesource-earlyaccess-plugin-repository</id>
-            <url>https://repo.fusesource.com/nexus/content/groups/ea</url>
+            <url>https://${jbossNexus}/nexus/content/groups/ea</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/medium-fuse-eap/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/medium-fuse-eap/pom.xml
@@ -205,7 +205,7 @@
         </repository>
         <repository>
             <id>fusesource-release-repository</id>
-            <url>https://repo.fusesource.com/nexus/content/groups/public/</url>
+            <url>${fusesourceNexusCommunity}/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -215,7 +215,7 @@
         </repository>
         <repository>
             <id>fusesource-earlyaccess-repository</id>
-            <url>https://repo.fusesource.com/nexus/content/groups/ea</url>
+            <url>https://${jbossNexus}/nexus/content/groups/ea</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -247,7 +247,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>fusesource-release-plugin-repository</id>
-            <url>https://repo.fusesource.com/nexus/content/groups/public/</url>
+            <url>${fusesourceNexusCommunity}/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -257,7 +257,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>fusesource-earlyaccess-plugin-repository</id>
-            <url>https://repo.fusesource.com/nexus/content/groups/ea</url>
+            <url>https://${jbossNexus}/nexus/content/groups/ea</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/pom.xml
@@ -87,7 +87,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</repository>
 	</repositories>
 	<pluginRepositories>
@@ -101,7 +101,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</pluginRepository>
 	</pluginRepositories>
 	<build>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/pom.xml
@@ -78,7 +78,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</repository>
 		<repository>
 			<releases>
@@ -104,7 +104,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</pluginRepository>
 		<pluginRepository>
 			<releases>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/pom.xml
@@ -67,7 +67,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</repository>
 		<repository>
 			<releases>
@@ -93,7 +93,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</pluginRepository>
 		<pluginRepository>
 			<releases>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/pom.xml
@@ -72,7 +72,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</repository>
 		<repository>
 			<releases>
@@ -98,7 +98,7 @@
 			</snapshots>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 		</pluginRepository>
 		<pluginRepository>
 			<releases>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/pom.xml
@@ -138,7 +138,7 @@
       </snapshots>
       <id>fuse-public-repository</id>
       <name>FuseSource Community Release Repository</name>
-      <url>https://repo.fusesource.com/nexus/content/groups/public</url>
+      <url>${fusesourceNexusCommunity}</url>
     </repository>
     <repository>
       <releases>
@@ -176,7 +176,7 @@
       </snapshots>
       <id>fuse-public-repository</id>
       <name>FuseSource Community Release Repository</name>
-      <url>https://repo.fusesource.com/nexus/content/groups/public</url>
+      <url>${fusesourceNexusCommunity}</url>
     </pluginRepository>
     <pluginRepository>
       <releases>

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/resources/projectWithRedhatVersionNotEmbedded/pom.xml
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/resources/projectWithRedhatVersionNotEmbedded/pom.xml
@@ -31,7 +31,7 @@
 		<repository>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -58,7 +58,7 @@
 		<pluginRepository>
 			<id>fuse-public-repository</id>
 			<name>FuseSource Community Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/public</url>
+			<url>${fusesourceNexusCommunity}</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/examples/transformation/csv-to-xml/pom.xml
+++ b/examples/transformation/csv-to-xml/pom.xml
@@ -140,7 +140,7 @@
     <repository>
       <id>fusesource.ea.repo</id>
       <name>JBoss Fuse Early Access Repository</name>
-      <url>https://repo.fusesource.com/nexus/content/groups/ea</url>
+      <url>https://${jbossNexus}/nexus/content/groups/ea</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
@@ -152,7 +152,7 @@
     <repository>
       <id>fusesource.release.repo</id>
       <name>JBoss Fuse Release Repository</name>
-      <url>https://repo.fusesource.com/nexus/content/repositories/releases</url>
+      <url>${fusesourceNexusRelease}</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
@@ -164,7 +164,7 @@
     <repository>
       <id>jboss.public.repo</id>
       <name>JBoss Public Repository</name>
-      <url>http://repository.jboss.org/nexus/content/repositories/public</url>
+      <url>https://${jbossNexus}/nexus/content/repositories/public</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/examples/transformation/starter/pom.xml
+++ b/examples/transformation/starter/pom.xml
@@ -140,7 +140,7 @@
     <repository>
       <id>fusesource.ea.repo</id>
       <name>JBoss Fuse Early Access Repository</name>
-      <url>https://repo.fusesource.com/nexus/content/groups/ea</url>
+      <url>https://${jbossNexus}/nexus/content/groups/ea</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
@@ -152,7 +152,7 @@
     <repository>
       <id>fusesource.release.repo</id>
       <name>JBoss Fuse Release Repository</name>
-      <url>https://repo.fusesource.com/nexus/content/repositories/releases</url>
+      <url>${fusesourceNexusRelease}</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
@@ -164,7 +164,7 @@
     <repository>
       <id>jboss.public.repo</id>
       <name>JBoss Public Repository</name>
-      <url>http://repository.jboss.org/nexus/content/repositories/public</url>
+      <url>https://${jbossNexus}/nexus/content/repositories/public</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/examples/transformation/xml-to-json/pom.xml
+++ b/examples/transformation/xml-to-json/pom.xml
@@ -71,7 +71,7 @@
       </snapshots>
       <id>fusesource.ea.repo</id>
       <name>JBoss Fuse Early Access Repository</name>
-      <url>https://repo.fusesource.com/nexus/content/groups/ea</url>
+      <url>https://${jbossNexus}/nexus/content/groups/ea</url>
     </repository>
     <repository>
       <releases>
@@ -82,7 +82,7 @@
       </snapshots>
       <id>fusesource.release.repo</id>
       <name>JBoss Fuse Release Repository</name>
-      <url>https://repo.fusesource.com/nexus/content/repositories/releases</url>
+      <url>${fusesourceNexusRelease}</url>
     </repository>
     <repository>
       <releases>
@@ -93,7 +93,7 @@
       </snapshots>
       <id>jboss.public.repo</id>
       <name>JBoss Public Repository</name>
-      <url>http://repository.jboss.org/nexus/content/repositories/public</url>
+      <url>https://${jbossNexus}/nexus/content/repositories/public</url>
     </repository>
   </repositories>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,19 @@
 		<jackson.version>2.5.1</jackson.version>
 		<slf4j.version>1.7.5</slf4j.version>
 		<sonar.test.inclusions>**/*Test.*,**/test/**/*,**/*IT.*</sonar.test.inclusions>
+
+		<!-- fusesource nexus repos -->
+		<fusesourceNexusCommunity>https://repo.fusesource.com/nexus/content/groups/public</fusesourceNexusCommunity>
+		<!-- could use? <fusesourceNexusCommunity>https://${jbossNexus}/nexus/content/groups/public</fusesourceNexusCommunity> --> 
+		
+		<!-- <fusesourceNexusRelease>https://repo.fusesource.com/nexus/content/repositories/releases</fusesourceNexusRelease> -->
+		<!-- 
+			use this alternate path as computed from 
+			https://repository.jboss.org/nexus/#nexus-search;gav~org.apache.camel~camel-test~2.17.*630187~~ 
+			to resolve
+			https://repository.jboss.org/nexus/service/local/repositories/product-brms-ip-06_03_4-fuse-06_03_00/content/org/apache/camel/camel-test/2.17.0.redhat-630187/
+		-->
+		<fusesourceNexusRelease>https://${jbossNexus}/nexus/service/local/repositories/product-brms-ip-06_03_4-fuse-06_03_00/content/</fusesourceNexusRelease>
 	</properties>
 
 	<modules>
@@ -102,7 +115,7 @@
 		<repository>
 			<id>fusesource.ea.repo</id>
 			<name>JBoss Fuse Early Access Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/ea</url>
+			<url>https://${jbossNexus}/nexus/content/groups/ea</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -114,7 +127,7 @@
 		<repository>
 			<id>fusesource.release.repo</id>
 			<name>JBoss Fuse Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/repositories/releases</url>
+			<url>${fusesourceNexusRelease}</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -126,7 +139,7 @@
 		<repository>
 			<id>jboss.public.repo</id>
 			<name>JBoss Public Repository</name>
-			<url>http://repository.jboss.org/nexus/content/repositories/public</url>
+			<url>https://${jbossNexus}/nexus/content/repositories/public</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -141,11 +154,13 @@
 			<url>http://download.eng.bos.redhat.com/brewroot/repos/jb-fis-2.0-maven-build/latest/maven/</url>
 		</repository>
 
+		<!-- should this be changed to https://${jbossNexus}/nexus/service/local/staging/deploy/maven2/ for staged deployment, and therefore inherited from JBT parent pom?
 		<repository>
 			<id>fuse-early-access</id>
 			<name>Fuse Early Access - staging</name>
 			<url>https://origin-repository.jboss.org/nexus/content/</url>
 		</repository>
+		-->
 
 	</repositories>
 
@@ -153,7 +168,7 @@
 		<pluginRepository>
 			<id>fusesource.ea.repo</id>
 			<name>JBoss Fuse Early Access Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/groups/ea</url>
+			<url>https://${jbossNexus}/nexus/content/groups/ea</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -165,7 +180,7 @@
 		<pluginRepository>
 			<id>fusesource.release.repo</id>
 			<name>JBoss Fuse Release Repository</name>
-			<url>https://repo.fusesource.com/nexus/content/repositories/releases</url>
+			<url>${fusesourceNexusRelease}</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -177,7 +192,7 @@
 		<pluginRepository>
 			<id>jboss.public.repo</id>
 			<name>JBoss Public Repository</name>
-			<url>http://repository.jboss.org/nexus/content/repositories/public</url>
+			<url>https://${jbossNexus}/nexus/content/repositories/public</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>


### PR DESCRIPTION
FUSETOOLS-2392 experiment with using better nexus URLs to resolve dependencies; note that https://repo.fusesource.com/nexus/content/groups/ea redirects to repository.jboss.org so reuse that URL instead

Signed-off-by: nickboldt <nboldt@redhat.com>