### PR TITLE
JBIDE-24641 fix obsolete links to old github...

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -22,7 +22,7 @@ Subscribe at: https://lists.jboss.org/mailman/listinfo/jbosstools-fuse-dev
 Mail to: jbosstools-fuse-dev@lists.jboss.org
 
 ## Building
-If you want to know how to build the project and setup an Eclipse workspace for development please read the [build guide](https://github.com/fusesource/fuseide/blob/master/Build.md "Build Guide"). 
+If you want to know how to build the project and setup an Eclipse workspace for development please read the [build guide](https://github.com/jbosstools/jbosstools-fuse/blob/master/Build.md "Build Guide"). 
 
 ## Contributing
-If you want to contribute to Fuse Tooling make sure you read the [contribution guide](https://github.com/fusesource/fuseide/blob/master/Contributing.md "Contribution Guide").
+If you want to contribute to Fuse Tooling make sure you read the [contribution guide](https://github.com/jbosstools/jbosstools-fuse/blob/master/Contributing.md "Contribution Guide").


### PR DESCRIPTION
JBIDE-24641 fix obsolete links to old github repo

Signed-off-by: nickboldt <nboldt@redhat.com>