### PR TITLE
FUSETOOLS-2464 - use String instead of Charset as Jaxb property

### DIFF
--- a/core/plugins/org.fusesource.ide.imports/src/org/fusesource/ide/imports/sap/SapLibrariesFeatureArchive.java
+++ b/core/plugins/org.fusesource.ide.imports/src/org/fusesource/ide/imports/sap/SapLibrariesFeatureArchive.java
@@ -193,7 +193,7 @@ public class SapLibrariesFeatureArchive extends SAPArchive {
 		JAXBContext context = JAXBContext.newInstance(Feature.class);
 		Marshaller m = context.createMarshaller();
 		m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-		m.setProperty(Marshaller.JAXB_ENCODING, MANIFEST_ENCODING);
+		m.setProperty(Marshaller.JAXB_ENCODING, MANIFEST_ENCODING.name());
 		StringWriter stringWriter = new StringWriter();
 		m.marshal(feature, stringWriter);
 		


### PR DESCRIPTION
Jaxb is supporting only String

need to be tested on a built environment (cannot go to the end with dev environment)