### PR TITLE
Exclude Community version upper than 2.19 as the template is nto working

### DIFF
--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForCXFCodeFirstIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForCXFCodeFirstIT.java
@@ -58,6 +58,7 @@ public class FuseIntegrationProjectCreatorRunnableForCXFCodeFirstIT extends Fuse
 	@Test
 	public void testCXFCodeFirstJavaProjectCreation() throws Exception {
 		assumeFalse("2.18.x redhat version is not working, see https://issues.apache.org/jira/browse/CAMEL-10602", camelVersion.startsWith("2.18"));
+		assumeTrue("Community versions upper to 2.19 are not working with a Fuse BOM refering 2.18- versions, see https://issues.jboss.org/browse/FUSETOOLS-2442", camelVersion.contains("redhat") || camelVersion.contains("fuse"));
 		testProjectCreation("-CXFCodeFirstJavaProject-"+camelVersion, CamelDSLType.JAVA, "src/main/java/com/mycompany/camel/cxf/code/first/java/incident/CamelRoute.java", null);
 	}
 	


### PR DESCRIPTION
as-is due to Fuse bom version mismatch

Signed-off-by: Aurélien Pupier <apupier@redhat.com>