### PR TITLE
FUSETOOLS-2091 - Ensure arquilian xsd cache i availabel for test

### DIFF
--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/META-INF/MANIFEST.MF
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/META-INF/MANIFEST.MF
@@ -38,6 +38,7 @@ Require-Bundle: org.junit,
  org.eclipse.m2e.launching,
  org.jboss.tools.locus.mockito;bundle-version="1.9.5",
  org.fusesource.ide.branding;bundle-version="10.0.0",
- org.fusesource.ide.camel.tests.util;bundle-version="10.0.0"
+ org.fusesource.ide.camel.tests.util;bundle-version="10.0.0",
+ org.jboss.tools.as.catalog;bundle-version="3.3.0"
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Activator: org.fusesource.ide.projecttemplates.tests.integration.ProjectTemplatesIntegrationTestsActivator


### PR DESCRIPTION
execution

Signed-off-by: Aurélien Pupier <apupier@redhat.com>