### PR TITLE
JBIDE-24788 add skipDeployToJBossOrg=false...

### DIFF
--- a/site/pom.xml
+++ b/site/pom.xml
@@ -13,4 +13,8 @@
 	<name>JBoss Fuse Tooling :: Update Site</name>
 	<packaging>eclipse-repository</packaging>
 
+	<properties>
+		<skipDeployToJBossOrg>false</skipDeployToJBossOrg>
+	</properties>
+
 </project>


### PR DESCRIPTION
JBIDE-24788 add skipDeployToJBossOrg=false so that the update site can be deployed (and the rest of the build will NOT re-deploy everything)

Signed-off-by: nickboldt <nboldt@redhat.com>