### PR TITLE
FUSETOOLS-2392 - Deactivating mouse wheel on combo requiring long

### DIFF
--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/DetailsSection.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/DetailsSection.java
@@ -279,6 +279,7 @@ public class DetailsSection extends FusePropertySection {
             // EXPRESSION PROPERTIES
             } else if (CamelComponentUtils.isExpressionProperty(prop)) {
             	CCombo choiceCombo = new CCombo(page, SWT.BORDER | SWT.FLAT | SWT.READ_ONLY | SWT.SINGLE);
+            	deactivateMouseWheel(choiceCombo);
                 getWidgetFactory().adapt(choiceCombo, true, true);
                 choiceCombo.setEditable(false);
 				choiceCombo.setLayoutData(createPropertyFieldLayoutData());
@@ -336,6 +337,7 @@ public class DetailsSection extends FusePropertySection {
              // DATAFORMAT PROPERTIES
             } else if (CamelComponentUtils.isDataFormatProperty(prop)) {
             	CCombo choiceCombo = new CCombo(page, SWT.BORDER | SWT.FLAT | SWT.READ_ONLY | SWT.SINGLE);
+            	deactivateMouseWheel(choiceCombo);
                 getWidgetFactory().adapt(choiceCombo, true, true);
                 choiceCombo.setEditable(false);
 				choiceCombo.setLayoutData(createPropertyFieldLayoutData());
@@ -460,6 +462,11 @@ public class DetailsSection extends FusePropertySection {
         }
         page.layout();
     }
+
+	protected void deactivateMouseWheel(CCombo choiceCombo) {
+		choiceCombo.addListener(SWT.MouseVerticalWheel, event -> event.doit = false);
+		choiceCombo.addListener(SWT.MouseWheel, event -> event.doit = false);
+	}
 
 	boolean shouldHidePropertyFromGroup(final String group, Parameter p, String currentPropertyGroup) {
 		return isNotMatchingGroup(group, currentPropertyGroup)


### PR DESCRIPTION
computing

when changing languages or dataformat types, it might require a long
computation time due to download + compile time.
As this feature is making a bad experience to Users (UI freeze), we
choose to deactivate it.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>