### PR TITLE
FUSETOOLS-2530 - Ensure use UI thread when calling asynExec

### DIFF
--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/navigator/CamelCtxNavContentProvider.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/navigator/CamelCtxNavContentProvider.java
@@ -187,7 +187,7 @@ public class CamelCtxNavContentProvider implements ICommonContentProvider, IReso
 
 			if (contents.containsKey(resource) && !Widgets.isDisposed(mViewer)) {
 	        	contents.remove(resource);
-	        	Display.getCurrent().asyncExec( () -> mViewer.refresh());
+	        	Display.getDefault().asyncExec( () -> mViewer.refresh());
 	        	return false;
 	        }
 			return true; // visit the children


### PR DESCRIPTION
Display.getCurrent is returning null if it is not UI Thread

Signed-off-by: Aurélien Pupier <apupier@redhat.com>