### PR TITLE
FUSETOOLS-2394 - report error validation for same component id and

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/l10n/Messages.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/l10n/Messages.java
@@ -21,6 +21,7 @@ public class Messages extends NLS {
 	public static String NumberValidator_messageError;
 	public static String RequiredPropertyValidator_messageMissingParameter;
 	public static String eipWithoutChild;
+	public static String validationSameComponentIdAndComponentDefinitionId;
 
 	static {
 		// initialize resource bundle

--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/l10n/messages.properties
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/l10n/messages.properties
@@ -1,3 +1,4 @@
 NumberValidator_messageError=The parameter {0} requires a numeric value.
 RequiredPropertyValidator_messageMissingParameter=Parameter {0} is a mandatory field and cannot be empty.
 eipWithoutChild=This component must have a child
+validationSameComponentIdAndComponentDefinitionId=Parameter {0} cannot have the same value ({1}) as its component definition scheme.

--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/model/TextParameterValidator.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/model/TextParameterValidator.java
@@ -16,11 +16,14 @@ import java.util.List;
 import org.eclipse.core.databinding.validation.IValidator;
 import org.eclipse.core.databinding.validation.ValidationStatus;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.osgi.util.NLS;
 import org.fusesource.ide.camel.model.service.core.catalog.Parameter;
+import org.fusesource.ide.camel.model.service.core.catalog.components.Component;
 import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteContainerElement;
 import org.fusesource.ide.camel.model.service.core.util.CamelComponentUtils;
 import org.fusesource.ide.camel.model.service.core.util.PropertiesUtils;
+import org.fusesource.ide.camel.validation.l10n.Messages;
 import org.fusesource.ide.foundation.core.util.Strings;
 
 /**
@@ -108,6 +111,11 @@ public final class TextParameterValidator implements IValidator {
 					return ValidationStatus.warning("Parameter " + parameter.getName() + " is a mandatory field and cannot be empty.");
 				} else if (routeContainer != null && !routeContainer.isIDUnique((String) value)) {
 					return ValidationStatus.warning("Parameter " + parameter.getName() + " does not contain a unique value.");
+				} else {
+					Component component = PropertiesUtils.getComponentFor(camelModelElement);
+					if (component != null && value.equals(component.getScheme())) {
+						return ValidationStatus.error(NLS.bind(Messages.validationSameComponentIdAndComponentDefinitionId, parameter.getName(), value));
+					}
 				}
 			} else {
 				// by default we only check for a value != null and

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyAggregate.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyAggregate.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
             <aggregate id="aggregate1">
             	<correlationExpression>
             		<constant>dummy</constant>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyFilter.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyFilter.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
             <filter id="_filter1">
                 <constant>dummy</constant>
             </filter>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyIdempotentConsumer.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyIdempotentConsumer.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
             <idempotentConsumer id="_idempotentConsumer1" messageIdRepositoryRef="dummy">
                 <constant>dummy</constant>
             </idempotentConsumer>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyIntercept.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyIntercept.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
  			<intercept id="_intercept1"/>
         </route>
     </camelContext>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyInterceptFrom.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyInterceptFrom.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
  			<interceptFrom id="_interceptFrom1"/>
         </route>
     </camelContext>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyInterceptSendToEndpoint.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyInterceptSendToEndpoint.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
  			<interceptSendToEndpoint id="_interceptSendToEndpoint1" uri="dummy"/>
         </route>
     </camelContext>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyLoop.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyLoop.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
  			<loop id="_loop1">
                 <constant>dummy</constant>
             </loop>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyMulticast.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyMulticast.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
  			<multicast id="_multicast1"/>
         </route>
     </camelContext>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyOnCompletion.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyOnCompletion.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
  			<onCompletion id="_onCompletion1"/>
         </route>
     </camelContext>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyPipeline.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyPipeline.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
  			<split id="_split1">
                 <constant>dummy</constant>
             </split>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyPolicy.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyPolicy.xml
@@ -6,7 +6,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
  			<policy id="_policy1" ref="dummyForPolicy">
             </policy>
         </route>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyResequence.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyResequence.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
  			<resequence id="_resequence1">
                 <constant>dummy</constant>
             </resequence>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptySample.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptySample.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
  			<pipeline id="_pipeline1"/>
         </route>
     </camelContext>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptySplit.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptySplit.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
  			<pipeline id="_pipeline1"/>
         </route>
     </camelContext>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyThreads.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyThreads.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
  			<throttle id="_throttle1">
                 <constant>dummy</constant>
             </throttle>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyThrottle.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyThrottle.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
  			<threads id="_threads1"/>
         </route>
     </camelContext>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyTransacted.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithEmptyTransacted.xml
@@ -5,7 +5,7 @@
     <camelContext id="camelContext-4df065c2-b806-498e-b9d8-959716cfb416"
         trace="false" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
-        	<from id="timer" uri="timer:timerName"></from>
+        	<from id="timer1" uri="timer:timerName"></from>
  			 <transacted id="_transacted2"/>
         </route>
     </camelContext>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithSameComponentIdAndComponentDefintionId.xml
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/resources/routeWithSameComponentIdAndComponentDefintionId.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:camel="http://camel.apache.org/schema/spring"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+    <camelContext id="camelContextId"
+        trace="false" xmlns="http://camel.apache.org/schema/spring">
+        <route id="routeId">
+        	<from id="twitter" uri="twitter:kind"/>
+        </route>
+    </camelContext>
+</beans>

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/src/org/fusesource/ide/camel/validation/xml/XMLCamelRoutesValidatorCheckIdIT.java
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/src/org/fusesource/ide/camel/validation/xml/XMLCamelRoutesValidatorCheckIdIT.java
@@ -23,5 +23,10 @@ public class XMLCamelRoutesValidatorCheckIdIT extends AbstractXMLCamelRouteValid
 	public void testValidateWithCamelContextAndRouteWithSameIdReportsError() throws Exception {
 		testValidateCreatesAValidationMarker("routeWithCamelContextAndRouteDuplicatedId.xml");
 	}
+	
+	@Test
+	public void testValidateWithSameComponentIdAndComponentDefintionIdReportsError() throws Exception {
+		testValidateCreatesAValidationMarker("routeWithSameComponentIdAndComponentDefintionId.xml");
+	}
 
 }


### PR DESCRIPTION
component definition id

in initial issue it was mentioned to add a warning also for cross-components because it is working but not a best practice.
I fear performance issue so maybe better to investigate more for the second part in another PR (perhaps issue too) to decide to decide to do it or not