### PR TITLE
FUSETOOLS-2547 Note: upstream repo variables...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,8 @@
 		<module>site</module>
 	</modules>
 
+	<!-- FUSETOOLS-2547 Note: upstream repo variables jbosstools-*-site are defined in jbosstools parent pom
+		 and so will throw a harmless resolution warning but WILL be resolved later when needed --> 
 	<repositories>
 		<repository>
 			<id>jbosstools-base</id>


### PR DESCRIPTION
FUSETOOLS-2547 Note: upstream repo variables jbosstools-*-site are defined in jbosstools parent pom and so will throw a harmless resolution warning but WILL be resolved later when needed

Signed-off-by: nickboldt <nboldt@redhat.com>