### PR TITLE
FUSETOOLS-2456 - apply Singleton pattern to avoid setting static

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/internal/CamelModelServiceCoreActivator.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/internal/CamelModelServiceCoreActivator.java
@@ -55,7 +55,7 @@ public class CamelModelServiceCoreActivator extends BaseUIPlugin {
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
 		setContext(context);
-		registerDebugOptionsListener(PLUGIN_ID, new Trace(this), context);
+		registerDebugOptionsListener(PLUGIN_ID, Trace.getInstance(this), context);
 		registerWorkspaceProjectListener();
 		JavaCore.addElementChangedListener(listener);
 	}

--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/internal/Trace.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/internal/Trace.java
@@ -21,14 +21,22 @@ import org.jboss.tools.foundation.core.plugin.AbstractTrace;
  * only for convenience and easy of use
  */
 public class Trace extends AbstractTrace implements DebugOptionsListener {
+	
 	private static Trace instance = null;
+	
 	/**
 	 * Trace constructor. This should never be explicitly called by clients and is used to register this class with the
 	 * {@link DebugOptions} service.
 	 */
-	Trace(CamelModelServiceCoreActivator p) {
+	private Trace(CamelModelServiceCoreActivator p) {
 		super(p);
-		instance = this;
+	}
+	
+	public static Trace getInstance(CamelModelServiceCoreActivator p) {
+		if(instance == null) {
+			instance = new Trace(p);
+		}
+		return instance;
 	}
 
 	public static void trace(final String level, String s) {


### PR DESCRIPTION
instances in a constructor

the parent should not be used static either so hard to do better than that but at least it removes the setting of static field in constructors (reported by Sonar as a code smell). I won't fight more on that as it is dead code and my personal point of view is that it should be completely removed.