### PR TITLE
JBDS-4574 - Don't override runtime name with folder name

### DIFF
--- a/servers/plugins/org.fusesource.ide.server.fuse.core/src/org/fusesource/ide/server/fuse/core/runtime/FuseESBRuntimeLocator.java
+++ b/servers/plugins/org.fusesource.ide.server.fuse.core/src/org/fusesource/ide/server/fuse/core/runtime/FuseESBRuntimeLocator.java
@@ -11,20 +11,9 @@
 
 package org.fusesource.ide.server.fuse.core.runtime;
 
-import java.io.File;
-
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.wst.server.core.IRuntimeType;
-import org.eclipse.wst.server.core.IRuntimeWorkingCopy;
-import org.eclipse.wst.server.core.IServerType;
-import org.eclipse.wst.server.core.ServerCore;
-import org.fusesource.ide.server.fuse.core.Activator;
 import org.fusesource.ide.server.fuse.core.bean.FuseBeanProvider;
 import org.fusesource.ide.server.karaf.core.runtime.KarafRuntimeLocator;
 import org.jboss.ide.eclipse.as.core.server.bean.ServerBean;
-import org.jboss.ide.eclipse.as.core.server.bean.ServerBeanLoader;
 import org.jboss.ide.eclipse.as.core.server.bean.ServerBeanType;
 
 
@@ -33,51 +22,12 @@ import org.jboss.ide.eclipse.as.core.server.bean.ServerBeanType;
  */
 public class FuseESBRuntimeLocator extends KarafRuntimeLocator {
 	
-	/**
-	 * empty default constructor
-	 */
-	public FuseESBRuntimeLocator() {
-	}
-
-	/**
-	 * retrieves the runtime working copy from the given folder
-	 * 
-	 * @param dir		the possible base folder
-	 * @param monitor	the monitor
-	 * @return			the runtime working copy or null if invalid
-	 */
 	@Override
-	public IRuntimeWorkingCopy getRuntimeFromDir(File dir, IProgressMonitor monitor) {
-		String absolutePath = dir.getAbsolutePath();
-		ServerBeanLoader l = new ServerBeanLoader(dir);
-		ServerBean sb = l.getServerBean();
-		if( sb != null ) {
+	protected boolean isValidServerBeanType(ServerBean sb) {
+		if (sb != null) {
 			ServerBeanType type = sb.getBeanType();
-			if( type != null ) {
-				if( type.equals(FuseBeanProvider.FUSE_6x)) {
-					String serverType = l.getServerAdapterId();
-					if( serverType != null ) {
-						IServerType t = ServerCore.findServerType(serverType);
-						if( t != null ) {
-							IRuntimeType rtt = t.getRuntimeType();
-							try {
-								IRuntimeWorkingCopy runtime = rtt.createRuntime(rtt.getId(), monitor);
-								// commented out the naming of the runtime as it seems to break server to runtime links
-								runtime.setName(dir.getName());
-								runtime.setLocation(new Path(absolutePath));
-								IStatus status = runtime.validate(monitor);
-								if (status == null || status.getSeverity() != IStatus.ERROR) {
-									return runtime;
-								}
-							} catch (Exception e) {
-								Activator.getLogger().error(e);
-							}
-						}
-					}
-					
-				}
-			}
+			return FuseBeanProvider.FUSE_6x.equals(type);	
 		}
-		return null;
+		return false;		
 	}
 }

--- a/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/runtime/KarafRuntimeLocator.java
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/runtime/KarafRuntimeLocator.java
@@ -39,9 +39,6 @@ public class KarafRuntimeLocator extends RuntimeLocatorDelegate {
 
 	private static final int MAX_RECURSION_DEPTH = 5;
 	
-	/* (non-Javadoc)
-	 * @see org.eclipse.wst.server.core.model.RuntimeLocatorDelegate#searchForRuntimes(org.eclipse.core.runtime.IPath, org.eclipse.wst.server.core.model.RuntimeLocatorDelegate.IRuntimeSearchListener, org.eclipse.core.runtime.IProgressMonitor)
-	 */
 	@Override
 	public void searchForRuntimes(IPath path, IRuntimeSearchListener listener,
 			IProgressMonitor monitor) {
@@ -130,8 +127,6 @@ public class KarafRuntimeLocator extends RuntimeLocatorDelegate {
 					IRuntimeType rtt = t.getRuntimeType();
 					try {
 						IRuntimeWorkingCopy runtime = rtt.createRuntime(rtt.getId(), monitor);
-						// commented out the naming of the runtime as it seems to break server to runtime links
-						runtime.setName(dir.getName());
 						runtime.setLocation(new Path(absolutePath));
 						IStatus status = runtime.validate(monitor);
 						if (status == null || status.getSeverity() != IStatus.ERROR) {
@@ -149,10 +144,9 @@ public class KarafRuntimeLocator extends RuntimeLocatorDelegate {
 	protected boolean isValidServerBeanType(ServerBean sb) {
 		if (sb != null) {
 			ServerBeanType type = sb.getBeanType();
-			return 	type != null && 
-					KarafBeanProvider.KARAF_2x.equals(type) || 
+			return KarafBeanProvider.KARAF_2x.equals(type) ||
 					KarafBeanProvider.KARAF_3x.equals(type) ||
-					KarafBeanProvider.KARAF_4x.equals(type);	
+					KarafBeanProvider.KARAF_4x.equals(type);
 		}
 		return false;		
 	}

--- a/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/runtime/integration/KarafRuntimeDetector.java
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/runtime/integration/KarafRuntimeDetector.java
@@ -53,7 +53,7 @@ public class KarafRuntimeDetector extends AbstractRuntimeDetectorDelegate {
 		ServerBeanType type = serverBean.getBeanType();
 		List<ServerBeanType> valid = Arrays.asList(getServerBeanTypes());
 		if( valid.contains(type)) {
-			return new RuntimeDefinition(serverBean.getName(), serverBean.getVersion(), type.getId(), new File(serverBean.getLocation()));
+			return new RuntimeDefinition(serverBean.getName(), serverBean.getVersion(), type.getId(), new File(serverBean.getLocation()), findMyDetector());
 		}
 		return null;
 	}

--- a/servers/tests/org.fusesource.ide.server.tests/META-INF/MANIFEST.MF
+++ b/servers/tests/org.fusesource.ide.server.tests/META-INF/MANIFEST.MF
@@ -16,4 +16,5 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.10.0",
  org.fusesource.ide.server.karaf.core;bundle-version="10.0.0",
  org.fusesource.ide.server.karaf.ui;bundle-version="10.0.0",
  org.fusesource.ide.server.fuse.core;bundle-version="10.0.0",
- org.fusesource.ide.server.fuse.ui;bundle-version="10.0.0"
+ org.fusesource.ide.server.fuse.ui;bundle-version="10.0.0",
+ org.assertj.core;bundle-version="2.1.0"

--- a/servers/tests/org.fusesource.ide.server.tests/src/main/java/org/fusesource/ide/server/tests/locator/FuseESBRuntime6xLocatorIT.java
+++ b/servers/tests/org.fusesource.ide.server.tests/src/main/java/org/fusesource/ide/server/tests/locator/FuseESBRuntime6xLocatorIT.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package org.fusesource.ide.server.tests.locator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collection;
 
 import junit.framework.TestCase;
@@ -57,16 +59,14 @@ public class FuseESBRuntime6xLocatorIT extends TestCase {
 	 */
 	@Test
 	public void testFuseESB() throws Exception {
-		IPath dest = FuseServerTestActivator.getDefault()
-				.getStateLocation().append(fRuntimeType);
-		FuseESBMockRuntimeCreationUtil.create6xRuntimeMock(
-				fRuntimeType, dest);
+		IPath dest = FuseServerTestActivator.getDefault().getStateLocation().append(fRuntimeType);
+		FuseESBMockRuntimeCreationUtil.create6xRuntimeMock(fRuntimeType, dest);
 		
 		FuseESBRuntimeLocator locator = new FuseESBRuntimeLocator();
 		MockListener listener = new MockListener();
-		locator.searchForRuntimes(dest, 
-				listener, new NullProgressMonitor());
-		assertTrue(listener.getFoundRuntime() != null);
+		locator.searchForRuntimes(dest, listener, new NullProgressMonitor());
+		
+		assertThat(listener.getFoundRuntime().getName()).contains("Red Hat JBoss Fuse 6");
 	}
 	
 	/**

--- a/servers/tests/org.fusesource.ide.server.tests/src/main/java/org/fusesource/ide/server/tests/locator/KarafRuntime2xLocatorIT.java
+++ b/servers/tests/org.fusesource.ide.server.tests/src/main/java/org/fusesource/ide/server/tests/locator/KarafRuntime2xLocatorIT.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package org.fusesource.ide.server.tests.locator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collection;
 
 import junit.framework.TestCase;
@@ -66,7 +68,7 @@ public class KarafRuntime2xLocatorIT extends TestCase {
 		MockListener listener = new MockListener();
 		locator.searchForRuntimes(dest, 
 				listener, new NullProgressMonitor());
-		assertTrue(listener.getFoundRuntime() != null);
+		assertThat(listener.getFoundRuntime().getName()).contains("Karaf 2");
 	}
 	
 	/**

--- a/servers/tests/org.fusesource.ide.server.tests/src/main/java/org/fusesource/ide/server/tests/locator/KarafRuntime3xLocatorIT.java
+++ b/servers/tests/org.fusesource.ide.server.tests/src/main/java/org/fusesource/ide/server/tests/locator/KarafRuntime3xLocatorIT.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package org.fusesource.ide.server.tests.locator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collection;
 
 import junit.framework.TestCase;
@@ -66,7 +68,7 @@ public class KarafRuntime3xLocatorIT extends TestCase {
 		MockListener listener = new MockListener();
 		locator.searchForRuntimes(dest, 
 				listener, new NullProgressMonitor());
-		assertTrue(listener.getFoundRuntime() != null);
+		assertThat(listener.getFoundRuntime().getName()).contains("Karaf 3");
 	}
 	
 	/**

--- a/servers/tests/org.fusesource.ide.server.tests/src/main/java/org/fusesource/ide/server/tests/locator/KarafRuntime4xLocatorIT.java
+++ b/servers/tests/org.fusesource.ide.server.tests/src/main/java/org/fusesource/ide/server/tests/locator/KarafRuntime4xLocatorIT.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package org.fusesource.ide.server.tests.locator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collection;
 
 import junit.framework.TestCase;
@@ -61,7 +63,7 @@ public class KarafRuntime4xLocatorIT extends TestCase {
 		KarafRuntimeLocator locator = new KarafRuntimeLocator();
 		MockListener listener = new MockListener();
 		locator.searchForRuntimes(dest, listener, new NullProgressMonitor());
-		assertTrue(listener.getFoundRuntime() != null);
+		assertThat(listener.getFoundRuntime().getName()).contains("Karaf 4");
 	}
 	
 	/**


### PR DESCRIPTION
it helps to keep consistent naming, especially when using Dev Suite installer

