### PR TITLE
JBIDE-25139 - Specify Maven Sonar plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,15 @@
 				</configuration>
 			</plugin>
 		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.sonarsource.scanner.maven</groupId>
+					<artifactId>sonar-maven-plugin</artifactId>
+					<version>3.3.0.603</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 
 	<dependencies>


### PR DESCRIPTION
it avoids to have too old version used which are not compatible with
Maven 3

Signed-off-by: Aurélien Pupier <apupier@redhat.com>