### PR TITLE
JBIDE-24766 fix copyrights in xml and...

### DIFF
--- a/core/plugins/org.fusesource.ide.tooling/about.properties
+++ b/core/plugins/org.fusesource.ide.tooling/about.properties
@@ -2,7 +2,8 @@ blurb=JBoss Fuse Tooling\n\
 \n\
 Version\: {featureVersion}\n\
 \n\
-JBoss, Home of Professional Open Source\n\
-Copyright (c) 2010-2013 Red Hat, Inc. and others.  All rights reserved.\n\
-\n\
-Visit http\://tools.jboss.org/features/apachecamel.html
+Copyright (c) 2010-2017 Red Hat, Inc. and others. \n\
+All rights reserved. This program and the accompanying materials \n\
+are made available under the terms of the Eclipse Public License v1.0 \n\
+which accompanies this distribution, and is available at \n\
+http://www.eclipse.org/legal/epl-v10.html

--- a/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/camel-context-cbr.xml
+++ b/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/camel-context-cbr.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    JBoss, Home of Professional Open Source
-    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2014-2017, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 

--- a/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/projects/test-route-manipulation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/projects/test-route-manipulation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    JBoss, Home of Professional Open Source
-    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2014-2017, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 

--- a/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/projects/trans217/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/projects/trans217/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,26 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- JBoss, Home of Professional Open Source Copyright 2014, Red Hat, Inc. 
-	and/or its affiliates, and individual contributors by the @authors tag. See 
-	the copyright.txt in the distribution for a full listing of individual contributors. 
-	Licensed under the Apache License, Version 2.0 (the "License"); you may not 
-	use this file except in compliance with the License. You may obtain a copy 
-	of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
-	by applicable law or agreed to in writing, software distributed under the 
-	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
-	OF ANY KIND, either express or implied. See the License for the specific 
-	language governing permissions and limitations under the License. -->
+<!--
+    Copyright 2014-2017, Red Hat, Inc. and/or its affiliates, and individual 
+    contributors by the @authors tag. See the copyright.txt in the 
+    distribution for a full listing of individual contributors. 
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
 <!-- This is the OSGi Blueprint XML file defining the Camel context and routes. 
-	Because the file is in the OSGI-INF/blueprint directory inside our JAR, it 
-	will be automatically activated as soon as the bundle is installed. The root 
-	element for any OSGi Blueprint file is 'blueprint' - you also see the namespace 
-	definitions for both the Blueprint and the Camel namespaces. -->
+    Because the file is in the OSGI-INF/blueprint directory inside our JAR, it 
+    will be automatically activated as soon as the bundle is installed. The root 
+    element for any OSGi Blueprint file is 'blueprint' - you also see the namespace 
+    definitions for both the Blueprint and the Camel namespaces. -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd                            http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
     <!-- The namespace for the camelContext element in Blueprint is 'https://camel.apache.org/schema/blueprint'. 
-		Additionally, we can also define namespace prefixes we want to use them in 
-		the XPath expressions in our CBR. While it is not required to assign id's 
-		to the <camelContext/> and <route/> elements, it is a good idea to set those 
-		for runtime management purposes (logging, JMX MBeans, ...) -->
+        Additionally, we can also define namespace prefixes we want to use them in 
+        the XPath expressions in our CBR. While it is not required to assign id's 
+        to the <camelContext/> and <route/> elements, it is a good idea to set those 
+        for runtime management purposes (logging, JMX MBeans, ...) -->
     <camelContext id="_context1" xmlns="http://camel.apache.org/schema/blueprint">
         <endpoint id="xml2json" uri="dozer:xml2json?sourceModel=generated_1500624415702.ABCOrder&amp;targetModel=xyzorder.XyzOrder&amp;marshalId=transform-json&amp;unmarshalId=generated_1500624415702&amp;mappingFile=transformation.xml"/>
         <dataFormats>


### PR DESCRIPTION
JBIDE-24766 fix copyrights in xml and about.properties files - replace the old 'JBoss, Home of Professional Open Source' with new 'Red Hat, Inc. and/or its affiliates'

Signed-off-by: nickboldt <nboldt@redhat.com>