### PR TITLE
FUSETOOLS-2580 - Remove sonar-maven-plugin management as it is

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,15 +286,6 @@
 				</configuration>
 			</plugin>
 		</plugins>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>org.sonarsource.scanner.maven</groupId>
-					<artifactId>sonar-maven-plugin</artifactId>
-					<version>3.3.0.603</version>
-				</plugin>
-			</plugins>
-		</pluginManagement>
 	</build>
 
 	<dependencies>


### PR DESCRIPTION
configured in parent now

Signed-off-by: Aurélien Pupier <apupier@redhat.com>