### PR TITLE
FUSETOOLS-2652 - Provide non-regression tests for route update through

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/jmx/camel/CamelContextMBean.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/jmx/camel/CamelContextMBean.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 public interface CamelContextMBean {
 
     String getId();
-
     String getCamelId();
 
     String getManagementName();
@@ -35,50 +34,35 @@ public interface CamelContextMBean {
     Map<String,String> getProperties();
     
     Boolean getTracing();
-    
     void setTracing(java.lang.Boolean tracing);
     
     Integer getInflightExchanges();
     
     void setTimeout(long timeout);
-    
     long getTimeout();
     
     void setTimeUnit(TimeUnit timeUnit);
-    
     TimeUnit getTimeUnit();
     
     void setShutdownNowOnTimeout(boolean shutdownNowOnTimeout);
-    
     boolean isShutdownNowOnTimeout();
     
     void start();
-    
     void stop();
-    
     void suspend();
-    
     void resume();
     
     void sendBody(String endpointUri, Object body);
-    
     void sendStringBody(String endpointUri, String body);
-    
     void sendBodyAndHeaders(String endpointUri, Object body, java.util.Map<String, Object> headers);
-    
     Object requestBody(String endpointUri, Object body);
-    
     Object requestStringBody(String endpointUri, String body);
-    
     Object requestBodyAndHeaders(String endpointUri, Object body, Map<String, Object> headers);
     
     String dumpRoutesAsXml();
-    
     void addOrUpdateRoutesFromXml(String xml);
-
     String dumpRoutesStatsAsXml(boolean fullStats, boolean includeProcessors);
 
     boolean createEndpoint(String uri);
-
     int removeEndpoints(String pattern);
 }

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelDebugTarget.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelDebugTarget.java
@@ -14,6 +14,8 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 
+import javax.management.MBeanServerConnection;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IMarkerDelta;
@@ -685,4 +687,8 @@ public class CamelDebugTarget extends CamelDebugElement implements IDebugTarget 
 	public ThreadGarbageCollector getGarbageCollector() {
 		return garbageCollector;
 }
+
+	public MBeanServerConnection getMBeanConnection() {
+		return conJob.getMBeanConnection();
+	}
 }

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/JMXCamelConnectJob.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/JMXCamelConnectJob.java
@@ -202,6 +202,9 @@ public class JMXCamelConnectJob extends Job {
 	public boolean belongsTo(Object family) {
 		return JMX_CONNECT_JOB_FAMILY.equals(family) || super.belongsTo(family);
 	}
-	
+
+	public MBeanServerConnection getMBeanConnection() {
+		return mBeanServerConnection;
+	}
 	
 }

--- a/editor/tests/org.fusesource.ide.launcher.tests.integration/META-INF/MANIFEST.MF
+++ b/editor/tests/org.fusesource.ide.launcher.tests.integration/META-INF/MANIFEST.MF
@@ -23,7 +23,9 @@ Require-Bundle: org.junit,
  org.fusesource.ide.camel.model.service.core.tests.integration;bundle-version="10.0.0",
  org.fusesource.ide.camel.tests.util;bundle-version="10.0.0",
  org.eclipse.m2e.core;bundle-version="1.7.1",
- org.fusesource.ide.camel.editor
+ org.fusesource.ide.camel.editor,
+ org.fusesource.ide.jmx.camel,
+ org.fusesource.ide.jmx.commons
 Bundle-Vendor: %Bundle-Vendor
 Export-Package: org.fusesource.ide.launcher.tests.integration.remote.debug
 Bundle-Activator: org.fusesource.ide.launcher.tests.integration.Activator

--- a/editor/tests/org.fusesource.ide.launcher.tests.integration/src/main/java/org/fusesource/ide/launcher/tests/integration/remote/debug/RemoteCamelLaunchConfigurationDelegateOverJolokiaIT.java
+++ b/editor/tests/org.fusesource.ide.launcher.tests.integration/src/main/java/org/fusesource/ide/launcher/tests/integration/remote/debug/RemoteCamelLaunchConfigurationDelegateOverJolokiaIT.java
@@ -66,7 +66,7 @@ public class RemoteCamelLaunchConfigurationDelegateOverJolokiaIT extends Abstrac
 		Map<String,Object> map = new HashMap<>();
 		map.put(JolokiaConnectionWrapper.ID, RemoteCamelLaunchConfigurationDelegateOverJolokiaIT.class.getName());
 		map.put(JolokiaConnectionWrapper.URL, JOLOKIA_URL);
-		map.put(JolokiaConnectionWrapper.GET_OR_POST, "GET");
+		map.put(JolokiaConnectionWrapper.GET_OR_POST, "POST");
 		map.put(JolokiaConnectionWrapper.IGNORE_SSL_ERRORS, true);
 		map.put(JolokiaConnectionWrapper.HEADERS, Collections.EMPTY_MAP);
 		jolokiaConnection = provider.createConnection(map);

--- a/jmx/plugins/org.fusesource.ide.jmx.camel/META-INF/MANIFEST.MF
+++ b/jmx/plugins/org.fusesource.ide.jmx.camel/META-INF/MANIFEST.MF
@@ -36,5 +36,6 @@ Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.fusesource.ide.jmx.camel.CamelJMXPlugin
 Bundle-ClassPath: .
 Export-Package: org.fusesource.ide.jmx.camel,
+ org.fusesource.ide.jmx.camel.internal;x-friends:="org.fusesource.ide.jmx.camel.tests.integration",
  org.fusesource.ide.jmx.camel.jmx.content.navigator.providers,
  org.fusesource.ide.jmx.camel.navigator;x-friends:="org.fusesource.ide.jmx.camel.tests.integration,org.fusesource.ide.jmx.diagram.view"


### PR DESCRIPTION
Jolokia

the bug was in JBoss Tools, see
https://issues.jboss.org/browse/JBIDE-25428 but worth having a
non-regression tests for this important use case

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

WARNING: it requires https://github.com/jbosstools/jbosstools-server/pull/549 to be merged