### PR TITLE
Fusetools 2195 select runtime camel version filter templates

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/adopters/AbstractProjectTemplate.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/adopters/AbstractProjectTemplate.java
@@ -84,4 +84,8 @@ public abstract class AbstractProjectTemplate {
 	 * @return the creator
 	 */
 	public abstract TemplateCreatorSupport getCreator(NewProjectMetaData projectMetaData);
+
+	public boolean isCompatible(String camelVersion) {
+		return true;
+	}
 }

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/impl/simple/AMQTemplate.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/impl/simple/AMQTemplate.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.projecttemplates.impl.simple;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.fusesource.ide.projecttemplates.adopters.AbstractProjectTemplate;
 import org.fusesource.ide.projecttemplates.adopters.configurators.MavenTemplateConfigurator;
 import org.fusesource.ide.projecttemplates.adopters.configurators.TemplateConfiguratorSupport;
@@ -25,6 +26,8 @@ import org.fusesource.ide.projecttemplates.util.NewProjectMetaData;
  * @author lhein
  */
 public class AMQTemplate extends AbstractProjectTemplate {
+	
+	private static ComparableVersion maximalCompatibleCamelVersion = new ComparableVersion("2.20.0");
 
 	@Override
 	public boolean supportsDSL(CamelDSLType type) {
@@ -34,6 +37,11 @@ public class AMQTemplate extends AbstractProjectTemplate {
 		case JAVA:		return false;
 		default:		return false;
 		}	
+	}
+	
+	@Override
+	public boolean isCompatible(String camelVersion) {
+		return new ComparableVersion(camelVersion).compareTo(maximalCompatibleCamelVersion) < 0;
 	}
 	
 	@Override

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/impl/simple/OSESpringBootXMLTemplate.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/impl/simple/OSESpringBootXMLTemplate.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.projecttemplates.impl.simple;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.fusesource.ide.projecttemplates.adopters.AbstractProjectTemplate;
 import org.fusesource.ide.projecttemplates.adopters.configurators.MavenTemplateConfigurator;
 import org.fusesource.ide.projecttemplates.adopters.configurators.TemplateConfiguratorSupport;
@@ -22,6 +23,13 @@ import org.fusesource.ide.projecttemplates.adopters.util.CamelDSLType;
 import org.fusesource.ide.projecttemplates.util.NewProjectMetaData;
 
 public class OSESpringBootXMLTemplate extends AbstractProjectTemplate {
+	
+	private static ComparableVersion minimalCompatibleCamelVersion = new ComparableVersion("2.18.0");
+	
+	@Override
+	public boolean isCompatible(String camelVersion) {
+		return new ComparableVersion(camelVersion).compareTo(minimalCompatibleCamelVersion) >= 0;
+	}
 	
 	@Override
 	public boolean supportsDSL(CamelDSLType type) {

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/internal/Messages.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/internal/Messages.java
@@ -84,6 +84,7 @@ public class Messages extends NLS {
 	public static String newProjectWizardTemplatePageTemplateProjectDescription;
 	public static String newProjectWizardTemplatePageDSLLabel;
 	public static String newProjectWizardTemplatePageFilterBoxText;
+	public static String newProjectWizardTemplatePageTemplateFilterMessageInformation;
 
 	public static String unzipStreamCreatorUnzippingTemplateFileMonitorMessage;
 	
@@ -99,7 +100,7 @@ public class Messages extends NLS {
 
 	public static String configuringFacets;
 	public static String installingRequiredFacetsForCamelProject;
-	
+
 	static {
         // initialize resource bundle
         NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/l10n/messages.properties
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/l10n/messages.properties
@@ -72,6 +72,7 @@ newProjectWizardTemplatePageTemplateProjectLabel = Use a predefined template
 newProjectWizardTemplatePageTemplateProjectDescription = Select this option if you would like to start with one of our predefined project templates.
 newProjectWizardTemplatePageDSLLabel = Select the project type
 newProjectWizardTemplatePageFilterBoxText = type filter text (filters on name, description and keywords)
+newProjectWizardTemplatePageTemplateFilterMessageInformation=The list of templates is filtered by the Camel version selected in previous page.
 unzipStreamCreatorUnzippingTemplateFileMonitorMessage=Unzipping template files...
 
 switchCamelVersionDialogName=Change Camel Version

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/FuseIntegrationProjectWizard.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/FuseIntegrationProjectWizard.java
@@ -41,25 +41,11 @@ public class FuseIntegrationProjectWizard extends Wizard implements INewWizard {
 		setNeedsProgressMonitor(true);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.ui.IWorkbenchWizard#init(org.eclipse.ui.IWorkbench, org.eclipse.jface.viewers.IStructuredSelection)
-	 */
 	@Override
 	public void init(IWorkbench workbench, IStructuredSelection selection) {
 		this.selection = selection;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.jface.wizard.Wizard#needsProgressMonitor()
-	 */
-	@Override
-	public boolean needsProgressMonitor() {
-		return true;
-	}
-
-	/* (non-Javadoc)
-	 * @see org.eclipse.jface.wizard.Wizard#performFinish()
-	 */
 	@Override
 	public boolean performFinish() {
 		final NewProjectMetaData metadata = getProjectMetaData();
@@ -76,9 +62,6 @@ public class FuseIntegrationProjectWizard extends Wizard implements INewWizard {
 		return true;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.jface.wizard.Wizard#addPages()
-	 */
 	@Override
 	public void addPages() {
 		super.addPages();
@@ -89,7 +72,7 @@ public class FuseIntegrationProjectWizard extends Wizard implements INewWizard {
 		runtimeAndCamelVersionPage = new FuseIntegrationProjectWizardRuntimeAndCamelPage();
 		addPage(runtimeAndCamelVersionPage);
 
-		templateSelectionPage = new FuseIntegrationProjectWizardTemplatePage();
+		templateSelectionPage = new FuseIntegrationProjectWizardTemplatePage(runtimeAndCamelVersionPage);
 		addPage(templateSelectionPage);
 	}
 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/FuseIntegrationProjectWizardRuntimeAndCamelPage.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/FuseIntegrationProjectWizardRuntimeAndCamelPage.java
@@ -79,9 +79,6 @@ public class FuseIntegrationProjectWizardRuntimeAndCamelPage extends WizardPage 
 		setPageComplete(false);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.jface.dialogs.IDialogPage#createControl(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	public void createControl(Composite parent) {
 		Composite container = new Composite(parent, SWT.NULL);
@@ -158,9 +155,7 @@ public class FuseIntegrationProjectWizardRuntimeAndCamelPage extends WizardPage 
 		camelVersionCombo.setText(CamelCatalogUtils.getLatestCamelVersion());
 		camelVersionCombo.setToolTipText(Messages.newProjectWizardRuntimePageCamelDescription);
 		camelVersionCombo.addSelectionListener(new SelectionAdapter() {
-			/* (non-Javadoc)
-			 * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
-			 */
+			
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				super.widgetSelected(e);
@@ -175,7 +170,10 @@ public class FuseIntegrationProjectWizardRuntimeAndCamelPage extends WizardPage 
 			}
 		});
 
-		camelVersionCombo.addModifyListener(e -> validate());
+		camelVersionCombo.addModifyListener(e -> {
+			validate();
+			((FuseIntegrationProjectWizardTemplatePage)getWizard().getPage(Messages.newProjectWizardTemplatePageName)).refresh(camelVersionCombo.getText());
+		});
 		
 		Button camelVersionValidationBtn = new Button(camelGrp, SWT.PUSH);
 		GridData camelButtonData = new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1);

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/FuseIntegrationProjectWizardTemplatePage.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/FuseIntegrationProjectWizardTemplatePage.java
@@ -42,18 +42,15 @@ import org.fusesource.ide.projecttemplates.wizards.pages.provider.TemplateLabelP
  */
 public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 
-	private Button btn_emptyProject;
-	private Button btn_templateProject;
-	private Button btn_blueprintDSL;
-	private Button btn_springDSL;
-	private Button btn_javaDSL;
+	private Button buttonEmptyProject;
+	private Button buttonTemplateProject;
+	private Button buttonBlueprintDSL;
+	private Button buttonSpringDSL;
+	private Button buttonJavaDSL;
 	
-	private FilteredTree list_templates;
+	private FilteredTree listTemplates;
 	private Text templateInfoText;
 	
-	/**
-	 * 
-	 */
 	public FuseIntegrationProjectWizardTemplatePage() {
 		super(Messages.newProjectWizardTemplatePageName);
 		setTitle(Messages.newProjectWizardTemplatePageTitle);
@@ -70,23 +67,19 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 		Composite container = new Composite(parent, SWT.NULL);
 		container.setLayout(new GridLayout(3, false));
 		
-		Label lbl_headline = new Label(container, SWT.None);
-		lbl_headline.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false, 3, 1));
-		lbl_headline.setText(Messages.newProjectWizardTemplatePageHeadlineLabel);
+		Label lblHeadline = new Label(container, SWT.None);
+		lblHeadline.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false, 3, 1));
+		lblHeadline.setText(Messages.newProjectWizardTemplatePageHeadlineLabel);
 		
-		Composite grp_emptyVsTemplate = new Composite(container, SWT.None);
+		Composite grpEmptyVsTemplate = new Composite(container, SWT.None);
 		GridLayout gridLayout = new GridLayout(1, false);
-		grp_emptyVsTemplate.setLayout(gridLayout);
-	    grp_emptyVsTemplate.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 3, 1));
+		grpEmptyVsTemplate.setLayout(gridLayout);
+	    grpEmptyVsTemplate.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 3, 1));
 	       
-	    btn_emptyProject = new Button(grp_emptyVsTemplate, SWT.RADIO);
-	    btn_emptyProject.setText(Messages.newProjectWizardTemplatePageEmptyProjectLabel);
-	    btn_emptyProject.setToolTipText(Messages.newProjectWizardTemplatePageEmptyProjectDescription);
-	    btn_emptyProject.addSelectionListener(new SelectionAdapter() {
-	    	/*
-	    	 * (non-Javadoc)
-	    	 * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
-	    	 */
+	    buttonEmptyProject = new Button(grpEmptyVsTemplate, SWT.RADIO);
+	    buttonEmptyProject.setText(Messages.newProjectWizardTemplatePageEmptyProjectLabel);
+	    buttonEmptyProject.setToolTipText(Messages.newProjectWizardTemplatePageEmptyProjectDescription);
+	    buttonEmptyProject.addSelectionListener(new SelectionAdapter() {
 	    	@Override
 	    	public void widgetSelected(SelectionEvent event) {
 	    		setTemplatesActive(false);
@@ -94,14 +87,10 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 	    	}
 	    });
 	    
-	    btn_templateProject = new Button(grp_emptyVsTemplate, SWT.RADIO);
-	    btn_templateProject.setText(Messages.newProjectWizardTemplatePageTemplateProjectLabel);
-	    btn_templateProject.setToolTipText(Messages.newProjectWizardTemplatePageTemplateProjectDescription);
-	    btn_templateProject.addSelectionListener(new SelectionAdapter() {
-	    	/*
-	    	 * (non-Javadoc)
-	    	 * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
-	    	 */
+	    buttonTemplateProject = new Button(grpEmptyVsTemplate, SWT.RADIO);
+	    buttonTemplateProject.setText(Messages.newProjectWizardTemplatePageTemplateProjectLabel);
+	    buttonTemplateProject.setToolTipText(Messages.newProjectWizardTemplatePageTemplateProjectDescription);
+	    buttonTemplateProject.addSelectionListener(new SelectionAdapter() {
 	    	@Override
 	    	public void widgetSelected(SelectionEvent event) {
 	    		setTemplatesActive(true);
@@ -109,13 +98,13 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 	    	}
 	    });
 
-	    Composite templates = new Composite(grp_emptyVsTemplate, SWT.None);
+	    Composite templates = new Composite(grpEmptyVsTemplate, SWT.None);
 	    GridData gd = new GridData(SWT.FILL, SWT.FILL, true, true, 3, 1);
 		gd.horizontalIndent = 20;
 	    templates.setLayoutData(gd);
 	    templates.setLayout(new GridLayout(2, true));
 	    
-	    list_templates = createFilteredTree(templates);
+	    listTemplates = createFilteredTree(templates);
 	    
 	    templateInfoText = new Text(templates, SWT.MULTI | SWT.READ_ONLY | SWT.WRAP | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL);
 	    templateInfoText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
@@ -123,61 +112,49 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 	    Label spacer = new Label(container, SWT.None);
 	    spacer.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, true, false, 3, 1));
 	    
-	    Label lbl_dsl = new Label(container, SWT.None);
-		lbl_dsl.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false, 3, 1));
-		lbl_dsl.setText(Messages.newProjectWizardTemplatePageDSLLabel);
+	    Label lblDsl = new Label(container, SWT.None);
+		lblDsl.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false, 3, 1));
+		lblDsl.setText(Messages.newProjectWizardTemplatePageDSLLabel);
 			    
-		Composite grp_dslSelection = new Composite(container, SWT.None);
+		Composite grpDslSelection = new Composite(container, SWT.None);
 	    gridLayout = new GridLayout(1, false);
-		grp_dslSelection.setLayout(gridLayout);
+		grpDslSelection.setLayout(gridLayout);
 		gd = new GridData(SWT.LEFT, SWT.TOP, true, false, 3, 1);
 		gd.horizontalIndent = 20;
-	    grp_dslSelection.setLayoutData(gd);
+	    grpDslSelection.setLayoutData(gd);
 	    
-	    btn_blueprintDSL = new Button(grp_dslSelection, SWT.RADIO);
-	    btn_blueprintDSL.setText(Messages.newProjectWizardTemplatePageBlueprintDSLLabel);
-	    btn_blueprintDSL.setToolTipText(Messages.newProjectWizardTemplatePageBlueprintDSLDescription);
-	    btn_blueprintDSL.addSelectionListener(new SelectionAdapter() {
-	    	/*
-	    	 * (non-Javadoc)
-	    	 * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
-	    	 */
+	    buttonBlueprintDSL = new Button(grpDslSelection, SWT.RADIO);
+	    buttonBlueprintDSL.setText(Messages.newProjectWizardTemplatePageBlueprintDSLLabel);
+	    buttonBlueprintDSL.setToolTipText(Messages.newProjectWizardTemplatePageBlueprintDSLDescription);
+	    buttonBlueprintDSL.addSelectionListener(new SelectionAdapter() {
 	    	@Override
 	    	public void widgetSelected(SelectionEvent event) {
 	    		validate();
 	    	}
 	    });
 	    
-	    btn_springDSL = new Button(grp_dslSelection, SWT.RADIO);
-	    btn_springDSL.setText(Messages.newProjectWizardTemplatePageSpringDSLLabel);
-	    btn_springDSL.setToolTipText(Messages.newProjectWizardTemplatePageSpringDSLDescription);
-	    btn_springDSL.addSelectionListener(new SelectionAdapter() {
-	    	/*
-	    	 * (non-Javadoc)
-	    	 * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
-	    	 */
+	    buttonSpringDSL = new Button(grpDslSelection, SWT.RADIO);
+	    buttonSpringDSL.setText(Messages.newProjectWizardTemplatePageSpringDSLLabel);
+	    buttonSpringDSL.setToolTipText(Messages.newProjectWizardTemplatePageSpringDSLDescription);
+	    buttonSpringDSL.addSelectionListener(new SelectionAdapter() {
 	    	@Override
 	    	public void widgetSelected(SelectionEvent event) {
 	    		validate();
 	    	}
 	    });
 	    
-	    btn_javaDSL = new Button(grp_dslSelection, SWT.RADIO);
-	    btn_javaDSL.setText(Messages.newProjectWizardTemplatePageJavaDSLLabel);
-	    btn_javaDSL.setToolTipText(Messages.newProjectWizardTemplatePageJavaDSLDescription);
-	    btn_javaDSL.addSelectionListener(new SelectionAdapter() {
-	    	/*
-	    	 * (non-Javadoc)
-	    	 * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
-	    	 */
+	    buttonJavaDSL = new Button(grpDslSelection, SWT.RADIO);
+	    buttonJavaDSL.setText(Messages.newProjectWizardTemplatePageJavaDSLLabel);
+	    buttonJavaDSL.setToolTipText(Messages.newProjectWizardTemplatePageJavaDSLDescription);
+	    buttonJavaDSL.addSelectionListener(new SelectionAdapter() {
 	    	@Override
 	    	public void widgetSelected(SelectionEvent event) {
 	    		validate();
 	    	}
 	    });
 
-	    btn_emptyProject.setSelection(true);
-	    btn_blueprintDSL.setSelection(true);
+	    buttonEmptyProject.setSelection(true);
+	    buttonBlueprintDSL.setSelection(true);
 	    
 		setControl(container);
 		
@@ -191,18 +168,14 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 	 */
 	private FilteredTree createFilteredTree(Composite parent) {
 		final int treeStyle = SWT.SINGLE | SWT.V_SCROLL | SWT.H_SCROLL | SWT.BORDER;
-		list_templates = new FilteredTree(parent, treeStyle, new TemplateNameAndKeywordPatternFilter(), true);
-		list_templates.getFilterControl().setMessage(Messages.newProjectWizardTemplatePageFilterBoxText);
-		list_templates.setLayoutData(GridDataFactory.swtDefaults().align(SWT.FILL, SWT.FILL).create());
-		list_templates.getViewer().setContentProvider(new TemplateContentProvider());
-		list_templates.getViewer().setLabelProvider(new TemplateLabelProvider());
-		list_templates.getViewer().addFilter(new ExcludeEmptyCategoriesFilter());
-		list_templates.getViewer().setInput(getTemplates());
-		list_templates.getViewer().addSelectionChangedListener(new ISelectionChangedListener() {
-			/*
-			 * (non-Javadoc)
-			 * @see org.eclipse.jface.viewers.ISelectionChangedListener#selectionChanged(org.eclipse.jface.viewers.SelectionChangedEvent)
-			 */
+		listTemplates = new FilteredTree(parent, treeStyle, new TemplateNameAndKeywordPatternFilter(), true);
+		listTemplates.getFilterControl().setMessage(Messages.newProjectWizardTemplatePageFilterBoxText);
+		listTemplates.setLayoutData(GridDataFactory.swtDefaults().align(SWT.FILL, SWT.FILL).create());
+		listTemplates.getViewer().setContentProvider(new TemplateContentProvider());
+		listTemplates.getViewer().setLabelProvider(new TemplateLabelProvider());
+		listTemplates.getViewer().addFilter(new ExcludeEmptyCategoriesFilter());
+		listTemplates.getViewer().setInput(getTemplates());
+		listTemplates.getViewer().addSelectionChangedListener(new ISelectionChangedListener() {
 			@Override
 			public void selectionChanged(SelectionChangedEvent event) {
 				if (!event.getSelection().isEmpty()) {
@@ -217,19 +190,19 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 				updateTemplateInfo(null);
 			}
 		});
-		return list_templates;
+		return listTemplates;
 	}
 	
 	private void updateTemplateInfo(TemplateItem template) {
 		if (template == null) {
-			btn_blueprintDSL.setEnabled(true);
-			btn_springDSL.setEnabled(true);
-			btn_javaDSL.setEnabled(true);
+			buttonBlueprintDSL.setEnabled(true);
+			buttonSpringDSL.setEnabled(true);
+			buttonJavaDSL.setEnabled(true);
 			templateInfoText.setText("");
 		} else {
-			btn_blueprintDSL.setEnabled(template.getTemplate().supportsDSL(CamelDSLType.BLUEPRINT));
-			btn_springDSL.setEnabled(template.getTemplate().supportsDSL(CamelDSLType.SPRING));
-			btn_javaDSL.setEnabled(template.getTemplate().supportsDSL(CamelDSLType.JAVA));
+			buttonBlueprintDSL.setEnabled(template.getTemplate().supportsDSL(CamelDSLType.BLUEPRINT));
+			buttonSpringDSL.setEnabled(template.getTemplate().supportsDSL(CamelDSLType.SPRING));
+			buttonJavaDSL.setEnabled(template.getTemplate().supportsDSL(CamelDSLType.JAVA));
 			templateInfoText.setText(template.getDescription());
 		}
 		validate();
@@ -243,21 +216,21 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 	}
 	
 	private void setTemplatesActive(boolean active) {
-		list_templates.getViewer().getTree().setEnabled(active);
-		list_templates.getViewer().getTree().getParent().setEnabled(active);
-		list_templates.getFilterControl().setEnabled(active);
-		list_templates.setEnabled(active);
+		listTemplates.getViewer().getTree().setEnabled(active);
+		listTemplates.getViewer().getTree().getParent().setEnabled(active);
+		listTemplates.getFilterControl().setEnabled(active);
+		listTemplates.setEnabled(active);
 		templateInfoText.setEnabled(active);
 		if (!active) {
 			// user selected Empty Project -> activate all DSL buttons
-			btn_blueprintDSL.setEnabled(true);
-			btn_springDSL.setEnabled(true);
-			btn_javaDSL.setEnabled(true);
+			buttonBlueprintDSL.setEnabled(true);
+			buttonSpringDSL.setEnabled(true);
+			buttonJavaDSL.setEnabled(true);
 		} else {
 			// user wants to use template -> activate dsl buttons if supported
-			btn_blueprintDSL.setEnabled(getSelectedTemplate() != null && getSelectedTemplate().getTemplate().supportsDSL(CamelDSLType.BLUEPRINT));
-			btn_springDSL.setEnabled(getSelectedTemplate() != null && getSelectedTemplate().getTemplate().supportsDSL(CamelDSLType.SPRING));
-			btn_javaDSL.setEnabled(getSelectedTemplate() != null && getSelectedTemplate().getTemplate().supportsDSL(CamelDSLType.JAVA));
+			buttonBlueprintDSL.setEnabled(getSelectedTemplate() != null && getSelectedTemplate().getTemplate().supportsDSL(CamelDSLType.BLUEPRINT));
+			buttonSpringDSL.setEnabled(getSelectedTemplate() != null && getSelectedTemplate().getTemplate().supportsDSL(CamelDSLType.SPRING));
+			buttonJavaDSL.setEnabled(getSelectedTemplate() != null && getSelectedTemplate().getTemplate().supportsDSL(CamelDSLType.JAVA));
 			updateDSLButtonGroup(getSelectedTemplate());
 		}
 	}
@@ -278,17 +251,17 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 	
 	private void selectButtonForDSL(CamelDSLType dsltype) {
 		if (dsltype.equals(CamelDSLType.BLUEPRINT)) {
-			btn_blueprintDSL.setSelection(true);
-			btn_javaDSL.setSelection(false);
-			btn_springDSL.setSelection(false);
+			buttonBlueprintDSL.setSelection(true);
+			buttonJavaDSL.setSelection(false);
+			buttonSpringDSL.setSelection(false);
 		} else if (dsltype.equals(CamelDSLType.JAVA)) {
-			btn_blueprintDSL.setSelection(false);
-			btn_javaDSL.setSelection(true);
-			btn_springDSL.setSelection(false);
+			buttonBlueprintDSL.setSelection(false);
+			buttonJavaDSL.setSelection(true);
+			buttonSpringDSL.setSelection(false);
 		} else {
-			btn_blueprintDSL.setSelection(false);
-			btn_javaDSL.setSelection(false);
-			btn_springDSL.setSelection(true);
+			buttonBlueprintDSL.setSelection(false);
+			buttonJavaDSL.setSelection(false);
+			buttonSpringDSL.setSelection(true);
 		}
 	}
 	
@@ -297,15 +270,15 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 	}
 	
 	private boolean disabledDSLSelected() {
-		return 	isSelectedAndDisabled(btn_blueprintDSL) ||
-				isSelectedAndDisabled(btn_javaDSL) ||
-				isSelectedAndDisabled(btn_springDSL);
+		return 	isSelectedAndDisabled(buttonBlueprintDSL) ||
+				isSelectedAndDisabled(buttonJavaDSL) ||
+				isSelectedAndDisabled(buttonSpringDSL);
 	}
 	
 	private void validate() {
-		if (btn_templateProject.getSelection() &&
-			(list_templates.getViewer().getSelection().isEmpty() || 
-			 Selections.getFirstSelection(list_templates.getViewer().getSelection()) instanceof CategoryItem || !isSelectedDSLSupported())) {
+		if (buttonTemplateProject.getSelection() &&
+			(listTemplates.getViewer().getSelection().isEmpty() || 
+			 Selections.getFirstSelection(listTemplates.getViewer().getSelection()) instanceof CategoryItem || !isSelectedDSLSupported())) {
 			setPageComplete(false);
 		} else {
 			setPageComplete(true);
@@ -319,11 +292,11 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 	 */
 	private boolean isSelectedDSLSupported() {
 		CamelDSLType dsl = null;
-		if (btn_blueprintDSL.getSelection()) {
+		if (buttonBlueprintDSL.getSelection()) {
 			dsl = CamelDSLType.BLUEPRINT;
-		} else if (btn_springDSL.getSelection()) {
+		} else if (buttonSpringDSL.getSelection()) {
 			dsl = CamelDSLType.SPRING;
-		} else if (btn_javaDSL.getSelection()) {
+		} else if (buttonJavaDSL.getSelection()) {
 			dsl = CamelDSLType.JAVA;
 		}
 		return 	dsl != null && 
@@ -338,8 +311,8 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 	 * @return
 	 */
 	public boolean isEmptyProject() {
-		if (!Widgets.isDisposed(btn_emptyProject)) {
-			return btn_emptyProject.getSelection();
+		if (!Widgets.isDisposed(buttonEmptyProject)) {
+			return buttonEmptyProject.getSelection();
 		} else {
 			return getSelectedTemplate() == null;
 		}
@@ -351,8 +324,8 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 	 * @return
 	 */
 	public boolean isTemplateProject() {
-		if (btn_templateProject != null && !btn_templateProject.isDisposed()) {
-			return btn_templateProject.getSelection();
+		if (buttonTemplateProject != null && !buttonTemplateProject.isDisposed()) {
+			return buttonTemplateProject.getSelection();
 		}
 		return false;
 	}
@@ -363,9 +336,9 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 	 * @return
 	 */
 	public TemplateItem getSelectedTemplate() {
-		if (btn_templateProject.getSelection() && 
-			!list_templates.getViewer().getSelection().isEmpty()) {
-			Object o = Selections.getFirstSelection(list_templates.getViewer().getSelection());
+		if (buttonTemplateProject.getSelection() && 
+			!listTemplates.getViewer().getSelection().isEmpty()) {
+			Object o = Selections.getFirstSelection(listTemplates.getViewer().getSelection());
 			if (o instanceof TemplateItem) {
 				return (TemplateItem)o;
 			}
@@ -374,44 +347,44 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 	}
 	
 	public CamelDSLType getDSL() {
-		if (btn_blueprintDSL.getSelection()) return CamelDSLType.BLUEPRINT;
-		if (btn_springDSL.getSelection()) return CamelDSLType.SPRING;
-		if (btn_javaDSL.getSelection()) return CamelDSLType.JAVA;
+		if (buttonBlueprintDSL.getSelection()) return CamelDSLType.BLUEPRINT;
+		if (buttonSpringDSL.getSelection()) return CamelDSLType.SPRING;
+		if (buttonJavaDSL.getSelection()) return CamelDSLType.JAVA;
 		return null;
 	}
 	
 	/**
 	 * /!\ Public for test purpose
 	 */
-	public FilteredTree getList_templates() {
-		return this.list_templates;
+	public FilteredTree getListTemplates() {
+		return this.listTemplates;
 	}
 	
 	/**
 	 * /!\ Public for test purpose
 	 */
-	public Button getBtn_blueprintDSL() {
-		return this.btn_blueprintDSL;
+	public Button getBtnBlueprintDSL() {
+		return this.buttonBlueprintDSL;
 	}
 	
 	/**
 	 * /!\ Public for test purpose
 	 */
-	public Button getBtn_javaDSL() {
-		return this.btn_javaDSL;
+	public Button getBtnJavaDSL() {
+		return this.buttonJavaDSL;
 	}
 	
 	/**
 	 * @return the btn_springDSL
 	 */
-	public Button getBtn_springDSL() {
-		return this.btn_springDSL;
+	public Button getBtnSpringDSL() {
+		return this.buttonSpringDSL;
 	}
 	
 	/**
 	 * /!\ Public for test purpose
 	 */
-	public Button getBtn_templateProject() {
-		return this.btn_templateProject;
+	public Button getBtnTemplateProject() {
+		return this.buttonTemplateProject;
 	}
 }

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/FuseIntegrationProjectWizardTemplatePage.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/FuseIntegrationProjectWizardTemplatePage.java
@@ -11,6 +11,8 @@
 package org.fusesource.ide.projecttemplates.wizards.pages;
 
 import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.wizard.WizardPage;
@@ -23,6 +25,8 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.FilteredTree;
 import org.fusesource.ide.foundation.ui.util.Selections;
 import org.fusesource.ide.foundation.ui.util.Widgets;
@@ -53,6 +57,8 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 	private Text templateInfoText;
 	private FuseIntegrationProjectWizardRuntimeAndCamelPage runtimeAndCamelVersionPage;
 	private CompatibleCamelVersionFilter compatibleCamelVersionFilter;
+	private Label filteredTemplatesInformationMessage;
+	private Label filteredTemplatesInformationIcon;
 	
 	public FuseIntegrationProjectWizardTemplatePage(FuseIntegrationProjectWizardRuntimeAndCamelPage runtimeAndCamelVersionPage) {
 		super(Messages.newProjectWizardTemplatePageName);
@@ -90,9 +96,6 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 
 		createTemplatesPanel(grpEmptyVsTemplate);
 
-		Label spacer = new Label(container, SWT.None);
-		spacer.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, true, false, 3, 1));
-
 		createDSLRadioButtons(container);
 
 		buttonEmptyProject.setSelection(true);
@@ -126,6 +129,21 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 
 		templateInfoText = new Text(templates, SWT.MULTI | SWT.READ_ONLY | SWT.WRAP | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL);
 		templateInfoText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		
+		createTemplatesBottomInformation(templates);
+	}
+
+	protected void createTemplatesBottomInformation(Composite templates) {
+		Composite infoComposite = new Composite(templates, SWT.NONE);
+		infoComposite.setLayoutData(GridDataFactory.fillDefaults().grab(true, false).span(2, 1).create());
+		infoComposite.setLayout(GridLayoutFactory.fillDefaults().numColumns(2).equalWidth(false).create());
+		
+		filteredTemplatesInformationIcon = new Label(infoComposite, SWT.NONE);
+		filteredTemplatesInformationIcon.setImage(PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_OBJS_INFO_TSK));
+		
+		filteredTemplatesInformationMessage = new Label(infoComposite, SWT.NONE);
+		filteredTemplatesInformationMessage.setText(Messages.newProjectWizardTemplatePageTemplateFilterMessageInformation);
+		filteredTemplatesInformationMessage.setFont(JFaceResources.getFontRegistry().getItalic(JFaceResources.DEFAULT_FONT));
 	}
 
 	protected void createDSLRadioButtons(Composite container) {
@@ -220,6 +238,8 @@ public class FuseIntegrationProjectWizardTemplatePage extends WizardPage {
 		listTemplates.getFilterControl().setEnabled(active);
 		listTemplates.setEnabled(active);
 		templateInfoText.setEnabled(active);
+		filteredTemplatesInformationIcon.setEnabled(active);
+		filteredTemplatesInformationMessage.setEnabled(active);
 		if (!active) {
 			// user selected Empty Project -> activate all DSL buttons
 			buttonBlueprintDSL.setEnabled(true);

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/filter/CompatibleCamelVersionFilter.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/filter/CompatibleCamelVersionFilter.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.fusesource.ide.projecttemplates.wizards.pages.filter;
+
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+import org.fusesource.ide.projecttemplates.wizards.pages.model.CategoryItem;
+import org.fusesource.ide.projecttemplates.wizards.pages.model.TemplateItem;
+
+public class CompatibleCamelVersionFilter extends ViewerFilter {
+	
+	private String camelVersion;
+
+	public CompatibleCamelVersionFilter(String camelVersion) {
+		this.setCamelVersion(camelVersion);
+	}
+
+	@Override
+	public boolean select(Viewer viewer, Object parentElement, Object element) {
+		if (element instanceof TemplateItem) {
+			return ((TemplateItem) element).isCompatible(camelVersion);
+		} else if (element instanceof CategoryItem) {
+			return hasCompatibleChildren((CategoryItem)element);
+		}
+		return true;
+	}
+
+	private boolean hasCompatibleChildren(CategoryItem category) {
+		boolean hasCompatibleTemplate = category.getTemplates().stream()
+				.filter(template -> template.isCompatible(camelVersion))
+				.findAny()
+				.isPresent();
+		if (!hasCompatibleTemplate) {
+			for (CategoryItem subCat : category.getSubCategories()) {
+				if (hasCompatibleChildren(subCat)) {
+					return true;
+				}
+			}
+		}
+		return hasCompatibleTemplate;
+	}
+
+	public void setCamelVersion(String camelVersion) {
+		this.camelVersion = camelVersion;
+	}
+
+}

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/filter/CompatibleCamelVersionFilter.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/filter/CompatibleCamelVersionFilter.java
@@ -35,9 +35,7 @@ public class CompatibleCamelVersionFilter extends ViewerFilter {
 
 	private boolean hasCompatibleChildren(CategoryItem category) {
 		boolean hasCompatibleTemplate = category.getTemplates().stream()
-				.filter(template -> template.isCompatible(camelVersion))
-				.findAny()
-				.isPresent();
+				.anyMatch(template -> template.isCompatible(camelVersion));
 		if (!hasCompatibleTemplate) {
 			for (CategoryItem subCat : category.getSubCategories()) {
 				if (hasCompatibleChildren(subCat)) {

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/filter/ExcludeEmptyCategoriesFilter.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/filter/ExcludeEmptyCategoriesFilter.java
@@ -18,9 +18,7 @@ import org.fusesource.ide.projecttemplates.wizards.pages.model.CategoryItem;
  * @author lhein
  */
 public class ExcludeEmptyCategoriesFilter extends ViewerFilter {
-	/* (non-Javadoc)
-	 * @see org.eclipse.jface.viewers.ViewerFilter#select(org.eclipse.jface.viewers.Viewer, java.lang.Object, java.lang.Object)
-	 */
+
 	@Override
 	public boolean select(Viewer viewer, Object parentElement, Object element) {
 		if (element instanceof CategoryItem) {
@@ -33,7 +31,9 @@ public class ExcludeEmptyCategoriesFilter extends ViewerFilter {
 		boolean empty = cat.getTemplates().isEmpty();
 		if (empty) {
 			for (CategoryItem subCat : cat.getSubCategories()) {
-				if (!isEmptyCategory(subCat)) return false;
+				if (!isEmptyCategory(subCat)) {
+					return false;
+				}
 			}
 		}
 		return empty;

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/model/TemplateItem.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/model/TemplateItem.java
@@ -74,10 +74,6 @@ public class TemplateItem implements NameAndWeightSupport {
 		return this.id;
 	}
 	
-	/*
-	 * (non-Javadoc)
-	 * @see org.fusesource.ide.projecttemplates.wizards.pages.model.NameAndWeightSupport#getName()
-	 */
 	@Override
 	public String getName() {
 		return this.name;
@@ -90,10 +86,6 @@ public class TemplateItem implements NameAndWeightSupport {
 		return this.description;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.fusesource.ide.projecttemplates.wizards.pages.model.NameAndWeightSupport#getWeight()
-	 */
 	@Override
 	public int getWeight() {
 		return this.weight;
@@ -111,5 +103,9 @@ public class TemplateItem implements NameAndWeightSupport {
 	 */
 	public AbstractProjectTemplate getTemplate() {
 		return this.template;
+	}
+
+	public boolean isCompatible(String camelVersion) {
+		return template.isCompatible(camelVersion);
 	}
 }

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/wizards/pages/FuseIntegrationProjectWizardTemplatePageIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/wizards/pages/FuseIntegrationProjectWizardTemplatePageIT.java
@@ -46,17 +46,17 @@ public class FuseIntegrationProjectWizardTemplatePageIT {
 		TemplateItem eapTemplate = findEAPTemplate(cats);
 		assertThat(eapTemplate).isNotNull();
 		
-		page.getBtn_templateProject().setSelection(true);
-		assertThat(page.getBtn_templateProject().getSelection());
+		page.getBtnTemplateProject().setSelection(true);
+		assertThat(page.getBtnTemplateProject().getSelection());
 		
-		page.getList_templates().getViewer().setSelection(new StructuredSelection(cbrTemplate));
-		assertThat(page.getBtn_javaDSL().isEnabled());
+		page.getListTemplates().getViewer().setSelection(new StructuredSelection(cbrTemplate));
+		assertThat(page.getBtnJavaDSL().isEnabled());
 		
-		page.getBtn_javaDSL().setSelection(true);
-		assertThat(page.getBtn_javaDSL().getSelection());
+		page.getBtnJavaDSL().setSelection(true);
+		assertThat(page.getBtnJavaDSL().getSelection());
 		
-		page.getList_templates().getViewer().setSelection(new StructuredSelection(eapTemplate));
-		assertThat(page.getBtn_blueprintDSL().getSelection());
+		page.getListTemplates().getViewer().setSelection(new StructuredSelection(eapTemplate));
+		assertThat(page.getBtnBlueprintDSL().getSelection());
 	}
 
 	private TemplateItem findEAPTemplate(List<CategoryItem> cats) {

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/wizards/pages/FuseIntegrationProjectWizardTemplatePageIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/wizards/pages/FuseIntegrationProjectWizardTemplatePageIT.java
@@ -47,16 +47,16 @@ public class FuseIntegrationProjectWizardTemplatePageIT {
 		assertThat(eapTemplate).isNotNull();
 		
 		page.getBtnTemplateProject().setSelection(true);
-		assertThat(page.getBtnTemplateProject().getSelection());
+		assertThat(page.getBtnTemplateProject().getSelection()).isTrue();
 		
 		page.getListTemplates().getViewer().setSelection(new StructuredSelection(cbrTemplate));
-		assertThat(page.getBtnJavaDSL().isEnabled());
+		assertThat(page.getBtnJavaDSL().isEnabled()).isTrue();
 		
 		page.getBtnJavaDSL().setSelection(true);
-		assertThat(page.getBtnJavaDSL().getSelection());
+		assertThat(page.getBtnJavaDSL().getSelection()).isTrue();
 		
 		page.getListTemplates().getViewer().setSelection(new StructuredSelection(eapTemplate));
-		assertThat(page.getBtnBlueprintDSL().getSelection());
+		assertThat(page.getBtnBlueprintDSL().getSelection()).isTrue();
 	}
 
 	private TemplateItem findEAPTemplate(List<CategoryItem> cats) {

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests/src/test/java/org/fusesource/ide/projecttemplates/wizards/pages/filter/CompatibleCamelVersionFilterTest.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests/src/test/java/org/fusesource/ide/projecttemplates/wizards/pages/filter/CompatibleCamelVersionFilterTest.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.fusesource.ide.projecttemplates.wizards.pages.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+import org.fusesource.ide.camel.model.service.core.util.CamelCatalogUtils;
+import org.fusesource.ide.projecttemplates.adopters.AbstractProjectTemplate;
+import org.fusesource.ide.projecttemplates.impl.simple.AMQTemplate;
+import org.fusesource.ide.projecttemplates.impl.simple.EmptyProjectTemplate;
+import org.fusesource.ide.projecttemplates.impl.simple.OSESpringBootXMLTemplate;
+import org.fusesource.ide.projecttemplates.wizards.pages.FuseIntegrationProjectWizardRuntimeAndCamelPage;
+import org.fusesource.ide.projecttemplates.wizards.pages.model.CategoryItem;
+import org.fusesource.ide.projecttemplates.wizards.pages.model.TemplateItem;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CompatibleCamelVersionFilterTest {
+	
+	@Mock
+	private FuseIntegrationProjectWizardRuntimeAndCamelPage page;
+	
+	@Test
+	public void testAMQCompatibleWith63() throws Exception {
+		CompatibleCamelVersionFilter filter = createFilter(CamelCatalogUtils.CAMEL_VERSION_LATEST_PRODUCTIZED_63);
+		TemplateItem templateItem = createTemplateItem(new AMQTemplate());
+		assertThat(filter.select(null, null, templateItem)).isTrue();
+	}
+
+	@Test
+	public void testAMQNotCompatibleWithHigherThan2_20() throws Exception {
+		CompatibleCamelVersionFilter filter = createFilter("2.20.0");
+		TemplateItem templateItem = createTemplateItem(new AMQTemplate());
+		assertThat(filter.select(null, null, templateItem)).isFalse();
+	}
+	
+	@Test
+	public void testOpenShiftTemplateNotCompatibleWithLowerThan2_18() throws Exception {
+		CompatibleCamelVersionFilter filter = createFilter("2.17.9");
+		TemplateItem templateItem = createTemplateItem(new OSESpringBootXMLTemplate());
+		assertThat(filter.select(null, null, templateItem)).isFalse();
+	}
+	
+	@Test
+	public void testOpenShiftTemplateCompatibleWithHigherThan2_18() throws Exception {
+		CompatibleCamelVersionFilter filter = createFilter(CamelCatalogUtils.CAMEL_VERSION_LATEST_FIS_20);
+		TemplateItem templateItem = createTemplateItem(new OSESpringBootXMLTemplate());
+		assertThat(filter.select(null, null, templateItem)).isTrue();
+	}
+
+	@Test
+	public void testCategoryItemNotFilteredOutIfContainsChild() throws Exception {
+		CompatibleCamelVersionFilter filter = createFilter("2.20.0");
+		CategoryItem category = new CategoryItem("id", "name", 0, null);
+		createTemplateItemInCategory(new EmptyProjectTemplate(), category);
+		assertThat(filter.select(null, null, category)).isTrue();
+	}
+	
+	@Test
+	public void testCategoryWithDepthTwoItemNotFilteredOutIfContainsChild() throws Exception {
+		CompatibleCamelVersionFilter filter = createFilter("2.20.0");
+		CategoryItem category1 = new CategoryItem("id1", "name", 0, null);
+		CategoryItem category2 = new CategoryItem("id2", "name", 0, category1.getName());
+		category2.setParentCategory(category1);
+		category1.addSubCategory(category2);
+		TemplateItem templateItem = createTemplateItemInCategory(new EmptyProjectTemplate(), category2);
+		assertThat(filter.select(null, null, category1)).isTrue();
+		assertThat(filter.select(null, null, category2)).isTrue();
+		assertThat(filter.select(null, null, templateItem)).isTrue();
+	}
+	
+	@Test
+	public void testCategoryItemFilteredOutIfAllChildrenAlsoFiltered() throws Exception {
+		CompatibleCamelVersionFilter filter = createFilter("2.17.0");
+		CategoryItem category = new CategoryItem("id", "name", 0, null);
+		createTemplateItemInCategory(new OSESpringBootXMLTemplate(), category);
+		assertThat(filter.select(null, null, category)).isFalse();
+	}
+
+	protected TemplateItem createTemplateItem(AbstractProjectTemplate template) {
+		return createTemplateItemInCategory(template, null);
+	}
+	
+	protected TemplateItem createTemplateItemInCategory(AbstractProjectTemplate template, CategoryItem category) {
+		TemplateItem templateItem = new TemplateItem("id", "name", "description", 1, category, template, "keywords");
+		if (category != null) {
+			category.addTemplate(templateItem);
+		}
+		return templateItem;
+	}
+	
+	protected CompatibleCamelVersionFilter createFilter(String camelVersion) {
+		doReturn(camelVersion).when(page).getSelectedCamelVersion();
+		return new CompatibleCamelVersionFilter(camelVersion);
+	}
+}

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests/src/test/java/org/fusesource/ide/projecttemplates/wizards/pages/filter/ExcludeEmptyCategoriesFilterTest.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests/src/test/java/org/fusesource/ide/projecttemplates/wizards/pages/filter/ExcludeEmptyCategoriesFilterTest.java
@@ -8,7 +8,7 @@
  * Contributors: 
  * Red Hat, Inc. - initial API and implementation 
  ******************************************************************************/ 
-package org.fusesource.ide.projecttemplates;
+package org.fusesource.ide.projecttemplates.wizards.pages.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
@lhein @bfitzpat What do you think to this way to provide different templates depending on camel version chosen in previous page?

- I think it will be easy to extend to filter base don Runtime too after.
- I think that it will greatly help with the Fuse 7 stuff, we will be able to provide a new Template completely different
- it allows to filter out the OpenShift template for Camel version < .18 which are not working for sure.