### PR TITLE
FUSETOOLS-2514 - Avoid to have error when pom.xml is missing

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/CamelMavenUtils.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/CamelMavenUtils.java
@@ -97,8 +97,14 @@ public class CamelMavenUtils {
 	 */
 	public IMavenProjectFacade getMavenProjectFacade(IProject project) {
 		final IMavenProjectRegistry projectRegistry = MavenPlugin.getMavenProjectRegistry();
-		final IFile pomIFile = project.getFile(new Path(IMavenConstants.POM_FILE_NAME));
-		return projectRegistry.create(pomIFile, true, new NullProgressMonitor());
+		IMavenProjectFacade res = projectRegistry.create(project, new NullProgressMonitor());
+		if (res == null) {
+			IFile pomIFile = project.getFile(new Path(IMavenConstants.POM_FILE_NAME));
+			if (pomIFile.exists()) {
+				res =  projectRegistry.create(pomIFile, true, new NullProgressMonitor());
+			}
+		}
+		return res;
 	}
 
 	public String getCamelVersionFromMaven(IProject project) {

--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/META-INF/MANIFEST.MF
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/META-INF/MANIFEST.MF
@@ -19,5 +19,6 @@ Require-Bundle: org.eclipse.core.filesystem,
  org.fusesource.ide.camel.model.service.core,
  org.fusesource.ide.camel.model.service.impl,
  org.fusesource.ide.camel.editor;bundle-version="10.0.0",
+ org.eclipse.m2e.maven.runtime;bundle-version="1.6.2",
  org.eclipse.m2e.core;bundle-version="1.7.1"
 Export-Package: org.fusesource.ide.camel.model.service.core.tests.integration.core.io

--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/java/org/fusesource/ide/camel/model/service/core/tests/integration/core/util/CamelMavenUtilsTestIT.java
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/java/org/fusesource/ide/camel/model/service/core/tests/integration/core/util/CamelMavenUtilsTestIT.java
@@ -10,12 +10,15 @@
  ******************************************************************************/
 package org.fusesource.ide.camel.model.service.core.tests.integration.core.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.InputStream;
+import java.util.List;
 
+import org.apache.maven.model.Repository;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -36,19 +39,28 @@ public class CamelMavenUtilsTestIT {
 	@Rule
 	public FuseProject fuseProject = new FuseProject("External Files");
 
+	private IFile pomFileInProject;
+
 	@Before
 	public void setup() throws CoreException {
-		InputStream inputStream = CamelMavenUtilsTestIT.class.getClassLoader().getResourceAsStream("/" + POM_NAME);
-		IFile fileInProject = fuseProject.getProject().getFile("pom.xml");
-		fileInProject.delete(true, null);
-		fileInProject.create(inputStream, true, new NullProgressMonitor());
+		pomFileInProject = fuseProject.getProject().getFile("pom.xml");
+		pomFileInProject.delete(true, null);
 	}
 
 	@Test
-	public void testUpdatePathParams() {
+	public void testUretrieveCamelVersionFromMaven() throws CoreException {
+		InputStream inputStream = CamelMavenUtilsTestIT.class.getClassLoader().getResourceAsStream("/" + POM_NAME);
+		pomFileInProject.create(inputStream, true, new NullProgressMonitor());
+		
 		String version = new CamelMavenUtils().getCamelVersionFromMaven(fuseProject.getProject());
 		assertNotNull("The retrieved camel version should not be null.", version);
 		assertNotEquals("The retrieved camel version should not resolve to the variable name.", "${camel.version}", version);
 		assertEquals("The retrieved version doesn't match the defined value in the pom file.", "2.19.0", version);
+	}
+	
+	@Test
+	public void testEmptyRepositoriesWhenPomMissing() {
+		List<Repository> repositories = new CamelMavenUtils().getRepositories(fuseProject.getProject(), new NullProgressMonitor());
+		assertThat(repositories).isEmpty();
 	}
 }


### PR DESCRIPTION
- not found a way to reproduce the reported error
- try to provide more robust way to retrieve the Maven project
- add test to cover more usecase

Signed-off-by: Aurélien Pupier <apupier@redhat.com>