### PR TITLE
FUSETOOLS-2715 - remove not existing folder from build.properties entry

### DIFF
--- a/syndesis/tests/org.fusesource.ide.syndesis.extension.ui.tests.integration/build.properties
+++ b/syndesis/tests/org.fusesource.ide.syndesis.extension.ui.tests.integration/build.properties
@@ -1,5 +1,4 @@
-source.. = src/main/resources/,\
-           src/main/java/
+source.. = src/main/java/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

## General

- [x] Did you use the Jira Issue number in the commit comments?
- [x] Did you set meaningful commit comments on each commit?
- [x] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Function

- [x] Does the project still build fine locally?
- [x] Does your modification work?
- [x] Is the non-happy path working, too?
- [x] Are other parts that use the same component still working fine?

## Code Style

- [x] Are method-/class-/variable-names meaningful?
- [x] Are methods concise, not too long?
- [x] Are catch blocks catching precise Exceptions only (no catch all)?
- [x] Have you used the correct file header copyright comment?
- [x] Have you set the correct year in the headers of new files?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
