### PR TITLE
FUSETOOLS-2717 - Provide ControlDecoration information on focus

### DIFF
--- a/core/plugins/org.fusesource.ide.foundation.ui/src/org/fusesource/ide/foundation/ui/util/ControlDecorationHelper.java
+++ b/core/plugins/org.fusesource.ide.foundation.ui/src/org/fusesource/ide/foundation/ui/util/ControlDecorationHelper.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.fusesource.ide.foundation.ui.util;
+
+import org.eclipse.jface.fieldassist.ControlDecoration;
+import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Control;
+
+public class ControlDecorationHelper {
+
+	public void addInformationOnFocus(Control control, String informationText) {
+		ControlDecoration decoration = new ControlDecoration(control, SWT.BOTTOM | SWT.LEFT);
+		Image image = FieldDecorationRegistry.getDefault().getFieldDecoration(FieldDecorationRegistry.DEC_INFORMATION).getImage();
+		decoration.setImage(image);
+		decoration.setShowOnlyOnFocus(true);
+		decoration.setDescriptionText(informationText);
+	}
+	
+}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/FusePropertySection.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/FusePropertySection.java
@@ -22,9 +22,6 @@ import org.eclipse.core.databinding.observable.map.WritableMap;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.draw2d.ColorConstants;
-import org.eclipse.jface.fieldassist.ControlDecoration;
-import org.eclipse.jface.fieldassist.FieldDecoration;
-import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.swt.SWT;
@@ -69,6 +66,7 @@ import org.fusesource.ide.camel.model.service.core.model.CamelBasicModelElement;
 import org.fusesource.ide.camel.model.service.core.util.CamelComponentUtils;
 import org.fusesource.ide.camel.model.service.core.util.PropertiesUtils;
 import org.fusesource.ide.foundation.core.util.Strings;
+import org.fusesource.ide.foundation.ui.util.ControlDecorationHelper;
 import org.w3c.dom.Node;
 
 /**
@@ -810,13 +808,7 @@ public abstract class FusePropertySection extends AbstractPropertySection {
 	protected void createHelpDecoration(Parameter parameter, Control control) {
 		String description = parameter.getDescription();
 		if (description != null) {
-			ControlDecoration helpDecoration = new ControlDecoration(control, SWT.BOTTOM | SWT.LEFT);
-			helpDecoration.setShowOnlyOnFocus(true);
-			FieldDecoration fieldDecoration = FieldDecorationRegistry.getDefault()
-					.getFieldDecoration(FieldDecorationRegistry.DEC_INFORMATION);
-			helpDecoration.setImage(fieldDecoration.getImage());
-			helpDecoration.setDescriptionText(description);
-			control.setToolTipText(description);
+			new ControlDecorationHelper().addInformationOnFocus(control, description);
 		}
 	}
 

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/creators/AbstractParameterPropertyUICreator.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/creators/AbstractParameterPropertyUICreator.java
@@ -19,9 +19,6 @@ import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.core.databinding.validation.IValidator;
 import org.eclipse.jface.databinding.fieldassist.ControlDecorationSupport;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
-import org.eclipse.jface.fieldassist.ControlDecoration;
-import org.eclipse.jface.fieldassist.FieldDecoration;
-import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
@@ -33,6 +30,7 @@ import org.fusesource.ide.camel.model.service.core.catalog.components.Component;
 import org.fusesource.ide.camel.model.service.core.catalog.eips.Eip;
 import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.util.PropertiesUtils;
+import org.fusesource.ide.foundation.ui.util.ControlDecorationHelper;
 
 /**
  * @author Aurelien Pupier
@@ -140,12 +138,7 @@ public abstract class AbstractParameterPropertyUICreator {
 	protected void createHelpDecoration(Parameter parameter, Control control) {
 		String description = parameter.getDescription();
 		if (description != null) {
-			ControlDecoration helpDecoration = new ControlDecoration(control, SWT.BOTTOM | SWT.LEFT);
-			helpDecoration.setShowOnlyOnFocus(true);
-			FieldDecoration fieldDecoration = FieldDecorationRegistry.getDefault().getFieldDecoration(FieldDecorationRegistry.DEC_INFORMATION);
-			helpDecoration.setImage(fieldDecoration.getImage());
-			helpDecoration.setDescriptionText(description);
-			control.setToolTipText(description);
+			new ControlDecorationHelper().addInformationOnFocus(control, description);
 		}
 	}
 

--- a/syndesis/plugins/org.fusesource.ide.syndesis.extension.ui/src/org/fusesource/ide/syndesis/extensions/ui/wizards/pages/SyndesisExtensionProjectWizardExtensionDetailsPage.java
+++ b/syndesis/plugins/org.fusesource.ide.syndesis.extension.ui/src/org/fusesource/ide/syndesis/extensions/ui/wizards/pages/SyndesisExtensionProjectWizardExtensionDetailsPage.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.syndesis.extensions.ui.wizards.pages;
 import java.util.Arrays;
 import java.util.List;
 
+import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
@@ -22,6 +23,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.fusesource.ide.foundation.core.util.Strings;
+import org.fusesource.ide.foundation.ui.util.ControlDecorationHelper;
 import org.fusesource.ide.foundation.ui.util.Widgets;
 import org.fusesource.ide.syndesis.extensions.ui.internal.Messages;
 import org.fusesource.ide.syndesis.extensions.ui.internal.SyndesisExtensionsUIActivator;
@@ -45,9 +47,6 @@ public class SyndesisExtensionProjectWizardExtensionDetailsPage extends WizardPa
 		setPageComplete(false);
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.eclipse.jface.dialogs.IDialogPage#createControl(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	public void createControl(Composite parent) {
 		Composite container = new Composite(parent, SWT.NULL);
@@ -69,12 +68,15 @@ public class SyndesisExtensionProjectWizardExtensionDetailsPage extends WizardPa
 		Label l = new Label(container, SWT.NONE);
 		l.setText(label);
 		
-		GridData gridData = new GridData(SWT.FILL, SWT.TOP, true, false, 2, 1);
+		GridData gridData = GridDataFactory.fillDefaults().grab(true, false).span(2, 1).indent(8, 0).create();
 		
 		// create the control
 		Text textField = new Text(container, SWT.BORDER);
 		textField.setLayoutData(gridData);
 		textField.setToolTipText(toolTip);
+		
+		new ControlDecorationHelper().addInformationOnFocus(textField, toolTip);
+		
 		if (!Strings.isBlank(message)) {
 			textField.setMessage(message);
 		}

--- a/syndesis/plugins/org.fusesource.ide.syndesis.extension.ui/src/org/fusesource/ide/syndesis/extensions/ui/wizards/pages/SyndesisExtensionProjectWizardVersionsPage.java
+++ b/syndesis/plugins/org.fusesource.ide.syndesis.extension.ui/src/org/fusesource/ide/syndesis/extensions/ui/wizards/pages/SyndesisExtensionProjectWizardVersionsPage.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package org.fusesource.ide.syndesis.extensions.ui.wizards.pages;
 
+import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
@@ -24,6 +25,7 @@ import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.fusesource.ide.foundation.core.util.Strings;
+import org.fusesource.ide.foundation.ui.util.ControlDecorationHelper;
 import org.fusesource.ide.foundation.ui.util.Widgets;
 import org.fusesource.ide.projecttemplates.util.CamelVersionChecker;
 import org.fusesource.ide.syndesis.extensions.ui.internal.Messages;
@@ -39,9 +41,6 @@ public class SyndesisExtensionProjectWizardVersionsPage extends WizardPage {
 	private Combo syndesisVersionCombo;
 	
 	private SelectionListener selectionListener = new SelectionAdapter() {
-		/* (non-Javadoc)
-		 * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
-		 */
 		@Override
 		public void widgetSelected(SelectionEvent e) {
 			validate();
@@ -56,9 +55,6 @@ public class SyndesisExtensionProjectWizardVersionsPage extends WizardPage {
 		setPageComplete(false);
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.eclipse.jface.dialogs.IDialogPage#createControl(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	public void createControl(Composite parent) {
 		Composite container = new Composite(parent, SWT.NULL);
@@ -66,20 +62,22 @@ public class SyndesisExtensionProjectWizardVersionsPage extends WizardPage {
 
 		Label springBootVersionLabel = new Label(container, SWT.NONE);
 		springBootVersionLabel.setText(Messages.newProjectWizardExtensionVersionsPageSpringBootVersionLabel);
-		GridData gridData = new GridData(SWT.FILL, SWT.TOP, true, false, 2, 1);
+		GridData gridData = GridDataFactory.fillDefaults().grab(true, false).span(2, 1).indent(8, 0).create();
 		springBootVersionCombo = new Combo(container, SWT.BORDER | SWT.DROP_DOWN);
 		springBootVersionCombo.setLayoutData(gridData);
 		springBootVersionCombo.setToolTipText(Messages.newProjectWizardExtensionVersionsPageSpringBootVersionTooltip);
+		new ControlDecorationHelper().addInformationOnFocus(springBootVersionCombo, Messages.newProjectWizardExtensionVersionsPageSpringBootVersionTooltip);
 		fillSpringBootVersions();
 		springBootVersionCombo.addSelectionListener(selectionListener);
 		springBootVersionCombo.addModifyListener( (ModifyEvent e) -> validate() );
 		
 		Label camelVersionLabel = new Label(container, SWT.NONE);
 		camelVersionLabel.setText(Messages.newProjectWizardExtensionVersionsPageCamelVersionLabel);
-		gridData = new GridData(SWT.FILL, SWT.TOP, true, false, 1, 1);
+		gridData = GridDataFactory.fillDefaults().grab(true, false).span(1, 1).indent(8, 0).create();
 		camelVersionCombo = new Combo(container, SWT.BORDER | SWT.DROP_DOWN);
 		camelVersionCombo.setLayoutData(gridData);
 		camelVersionCombo.setToolTipText(Messages.newProjectWizardExtensionVersionsPageCamelVersionTooltip);
+		new ControlDecorationHelper().addInformationOnFocus(camelVersionCombo, Messages.newProjectWizardExtensionVersionsPageCamelVersionTooltip);
 		fillCamelVersions();
 		camelVersionCombo.addSelectionListener(selectionListener);
 		camelVersionCombo.addModifyListener( (ModifyEvent e) -> validate() );
@@ -93,10 +91,11 @@ public class SyndesisExtensionProjectWizardVersionsPage extends WizardPage {
 		
 		Label syndesisVersionLabel = new Label(container, SWT.NONE);
 		syndesisVersionLabel.setText(Messages.newProjectWizardExtensionVersionsPageSyndesisVersionLabel);
-		gridData = new GridData(SWT.FILL, SWT.TOP, true, false, 2, 1);
+		gridData = GridDataFactory.fillDefaults().grab(true, false).span(2, 1).indent(8, 0).create();
 		syndesisVersionCombo = new Combo(container, SWT.BORDER | SWT.DROP_DOWN);
 		syndesisVersionCombo.setLayoutData(gridData);
 		syndesisVersionCombo.setToolTipText(Messages.newProjectWizardExtensionVersionsPageSyndesisVersionTooltip);
+		new ControlDecorationHelper().addInformationOnFocus(syndesisVersionCombo, Messages.newProjectWizardExtensionVersionsPageSyndesisVersionTooltip);
 		fillSyndesisVersions();
 		syndesisVersionCombo.addSelectionListener(selectionListener);
 		syndesisVersionCombo.addModifyListener( (ModifyEvent e) -> validate() );


### PR DESCRIPTION
except on WizardLocation page as it is fully duplicated code that needs
to be refactored

the icon is slightly cropped on the left but it is the case everywhere in Eclipse, I don't know how to get rid of it.
![image](https://user-images.githubusercontent.com/1105127/34413822-fd8f0f26-ebe5-11e7-9a91-70649ca3963c.png)



Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

## General

- [x] Did you use the Jira Issue number in the commit comments?
- [x] Did you set meaningful commit comments on each commit?
- [x] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Function

- [x] Does the project still build fine locally?
- [x] Does your modification work?
- [x] Is the non-happy path working, too?
- [x] Are other parts that use the same component still working fine?

## Code Style

- [x] Are method-/class-/variable-names meaningful?
- [x] Are methods concise, not too long?
- [x] Are catch blocks catching precise Exceptions only (no catch all)?
- [x] Have you used the correct file header copyright comment?
- [x] Have you set the correct year in the headers of new files?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
