### PR TITLE
Fusetools 2668 disable transformation editor for camel2.20+

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/actions/SwitchCamelVersionAction.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/actions/SwitchCamelVersionAction.java
@@ -10,8 +10,10 @@
  ******************************************************************************/
 package org.fusesource.ide.projecttemplates.actions;
 
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.window.Window;
@@ -22,6 +24,7 @@ import org.eclipse.ui.PlatformUI;
 import org.fusesource.ide.camel.model.service.core.util.CamelMavenUtils;
 import org.fusesource.ide.foundation.ui.util.Selections;
 import org.fusesource.ide.projecttemplates.actions.ui.SwitchCamelVersionWizard;
+import org.fusesource.ide.projecttemplates.internal.Messages;
 import org.fusesource.ide.projecttemplates.internal.ProjectTemplatesActivator;
 
 /**
@@ -42,12 +45,21 @@ public class SwitchCamelVersionAction implements IObjectActionDelegate {
 			if (Window.OK == new WizardDialog(PlatformUI.getWorkbench().getDisplay().getActiveShell(), switchCamelVersionWizard).open() ) {
 				String newVersion = switchCamelVersionWizard.getSelectedCamelVersion();
 				if (!newVersion.equalsIgnoreCase(currentVersion)) {
+					if (shouldWarnAboutDozerAPIBreak(currentVersion, newVersion)) {
+						MessageDialog.openInformation(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), Messages.dozerInformationApiBreakTitle, Messages.dozerInformationApiBreakMessage);
+					}
 					new ChangeCamelVersionJob(project, newVersion).schedule();
 				}
 			}
 		} else {
 			ProjectTemplatesActivator.pluginLog().logError("Cannot determine target project with selection of type " + selection.getClass().getName());
 		}
+	}
+
+	protected boolean shouldWarnAboutDozerAPIBreak(String currentVersion, String newVersion) {
+		ComparableVersion maxVersion = new ComparableVersion("2.20.0");
+		return maxVersion.compareTo(new ComparableVersion(newVersion)) <= 0 && maxVersion.compareTo(new ComparableVersion(currentVersion)) > 0
+				|| maxVersion.compareTo(new ComparableVersion(newVersion)) > 0 && maxVersion.compareTo(new ComparableVersion(currentVersion)) <= 0;
 	}
 
 	@Override

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/internal/Messages.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/internal/Messages.java
@@ -101,6 +101,9 @@ public class Messages extends NLS {
 	public static String configuringFacets;
 	public static String installingRequiredFacetsForCamelProject;
 
+	public static String dozerInformationApiBreakTitle;
+	public static String dozerInformationApiBreakMessage;
+
 	static {
         // initialize resource bundle
         NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/l10n/messages.properties
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/l10n/messages.properties
@@ -87,3 +87,6 @@ reOpenCamelEditorAfterVersionVersionChangeDialogText=The Camel version used in t
 
 configuringFacets=Configure Camel project facets
 installingRequiredFacetsForCamelProject=Installing required facets for Camel project
+
+dozerInformationApiBreakTitle=Information on Data Transformation (Dozer) API break
+dozerInformationApiBreakMessage=In case Data Transformation with Dozer is used, please note that manual modifications are required to make it working with Camel 2.20+.\n See Apache Dozer migration guide for the required manual updates.\n\n There is no Data Transformation Editor available with Camel version newer than 2.20.

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests/src/test/java/org/fusesource/ide/projecttemplates/actions/SwitchCamelVersionActionTest.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests/src/test/java/org/fusesource/ide/projecttemplates/actions/SwitchCamelVersionActionTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.fusesource.ide.projecttemplates.actions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class SwitchCamelVersionActionTest {
+	
+	@Parameters(name = "from {0} to {1}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {     
+                 { "2.19.3", "2.20.0", true},
+                 { "2.20.0", "2.20.1", false},
+                 { "2.19.3", "2.18.1", false},
+                 { "2.20.1", "2.19.3", true},
+           });
+    }
+    
+    @Parameter
+    public String oldVersion;
+
+    @Parameter(1)
+    public String newversion;
+    
+    @Parameter(2)
+    public boolean shouldWarn;
+
+	@Test
+	public void testShouldWarnAboutDozerAPIBreak() throws Exception {
+		assertThat(new SwitchCamelVersionAction().shouldWarnAboutDozerAPIBreak(oldVersion, newversion)).isEqualTo(shouldWarn);
+	}
+
+}

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/extensions/DataTransformationPaletteEntry.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/extensions/DataTransformationPaletteEntry.java
@@ -13,6 +13,7 @@ package org.jboss.tools.fuse.transformation.extensions;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.fusesource.ide.camel.editor.provider.ext.ICustomPaletteEntry;
@@ -52,7 +53,7 @@ public class DataTransformationPaletteEntry implements ICustomPaletteEntry {
 		Dependency dep = new Dependency();
 		dep.setGroupId(ORG_APACHE_CAMEL);
 		dep.setArtifactId(computeArtifactId(runtimeProvider));
-		dep.setVersion(CamelUtils.getCurrentProjectCamelVersion());
+		dep.setVersion(getCurrentProjectCamelVersion());
 		deps.add(dep);
 		return deps;
 	}
@@ -67,6 +68,11 @@ public class DataTransformationPaletteEntry implements ICustomPaletteEntry {
 
 	@Override
 	public boolean isValid(String runtimeProvider) {
-		return true;
+    	String camelVersion = getCurrentProjectCamelVersion();
+    	return new ComparableVersion("2.20.0").compareTo(new ComparableVersion(camelVersion)) > 0 ;
+	}
+
+	String getCurrentProjectCamelVersion() {
+		return CamelUtils.getCurrentProjectCamelVersion();
 	}
 }

--- a/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests/META-INF/MANIFEST.MF
+++ b/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests/META-INF/MANIFEST.MF
@@ -6,4 +6,5 @@ Bundle-Version: 10.2.0.qualifier
 Fragment-Host: org.jboss.tools.fuse.transformation.editor;bundle-version="10.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0",
- org.assertj.core;bundle-version="2.1.0"
+ org.assertj.core;bundle-version="2.1.0",
+ org.jboss.tools.locus.mockito;bundle-version="1.9.5"

--- a/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests/src/test/java/org/jboss/tools/fuse/transformation/extensions/DataTransformationPaletteEntryTest.java
+++ b/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests/src/test/java/org/jboss/tools/fuse/transformation/extensions/DataTransformationPaletteEntryTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.fuse.transformation.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+import org.fusesource.ide.camel.model.service.core.util.CamelCatalogUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DataTransformationPaletteEntryTest {
+	
+	@Spy
+	DataTransformationPaletteEntry dataTransformationPaletteEntry;
+	
+	@Test
+	public void testIsNotValidFor220() throws Exception {
+		checkNotSupportedVersion("2.20.0");
+	}
+	
+	@Test
+	public void testIsNotValidForLatestCamelCommunity() throws Exception {
+		checkNotSupportedVersion(CamelCatalogUtils.CAMEL_VERSION_LATEST_COMMUNITY);
+	}
+
+	protected void checkNotSupportedVersion(String notSupportedVersion) {
+		doReturn(notSupportedVersion).when(dataTransformationPaletteEntry).getCurrentProjectCamelVersion();
+		assertThat(dataTransformationPaletteEntry.isValid(null)).isFalse();
+	}
+	
+	@Test
+	public void testValidForLatestFuse63() throws Exception {
+		checkValid(CamelCatalogUtils.CAMEL_VERSION_LATEST_PRODUCTIZED_63);
+	}
+	
+	@Test
+	public void testValidForLatestFuse62() throws Exception {
+		checkValid(CamelCatalogUtils.CAMEL_VERSION_LATEST_PRODUCTIZED_62);
+	}
+
+	protected void checkValid(String validVersion) {
+		doReturn(validVersion).when(dataTransformationPaletteEntry).getCurrentProjectCamelVersion();
+		assertThat(dataTransformationPaletteEntry.isValid(null)).isTrue();
+	}
+
+}


### PR DESCRIPTION
- removed the Data Transformation from palette
- provide information when switching Camel version using different incompatible Dozer version

to go further (another PR?)
- check that there is effectively Dozer used when switching Camel version
- check Camel version/dozer file when opening an already migrated Dozer file

# Pull Request Checklist

## General

- [x] Did you use the Jira Issue number in the commit comments?
- [x] Did you set meaningful commit comments on each commit?
- [x] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Function

- [x] Does the project still build fine locally?
- [x] Does your modification work?
- [x] Is the non-happy path working, too?
- [x] Are other parts that use the same component still working fine?

## Code Style

- [x] Are method-/class-/variable-names meaningful?
- [x] Are methods concise, not too long?
- [x] Are catch blocks catching precise Exceptions only (no catch all)?
- [x] Have you used the correct file header copyright comment?
- [x] Have you set the correct year in the headers of new files?

## Tests

- [x] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
