### PR TITLE
FUSETOOLS-2714 - removed unused rule attribute tmpFolder from test

### DIFF
--- a/syndesis/tests/org.fusesource.ide.syndesis.extension.ui.tests.integration/src/main/java/org/fusesource/ide/syndesis/extensions/tests/integration/wizards/SyndesisExtensionProjectCreatorRunnableForSimpleIT.java
+++ b/syndesis/tests/org.fusesource.ide.syndesis.extension.ui.tests.integration/src/main/java/org/fusesource/ide/syndesis/extensions/tests/integration/wizards/SyndesisExtensionProjectCreatorRunnableForSimpleIT.java
@@ -10,14 +10,9 @@
  ******************************************************************************/
 package org.fusesource.ide.syndesis.extensions.tests.integration.wizards;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 public class SyndesisExtensionProjectCreatorRunnableForSimpleIT extends SyndesisExtensionProjectCreatorRunnableIT{
-	
-	@Rule
-	public TemporaryFolder tmpFolder = new TemporaryFolder();
 	
 	@Test
 	public void testSimpleExtensionProjectCreation() throws Exception {


### PR DESCRIPTION
Signed-off-by: Lars Heinemann <lhein.smx@gmail.com>

# Pull Request Checklist

## General

- [X] Did you use the Jira Issue number in the commit comments?
- [X] Did you set meaningful commit comments on each commit?
- [X] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Function

- [X] Does the project still build fine locally?
- [X] Does your modification work?
- [ ] Is the non-happy path working, too? -> not applicable
- [ ] Are other parts that use the same component still working fine? -> not applicable

## Code Style

- [ ] Are method-/class-/variable-names meaningful? -> not applicable
- [ ] Are methods concise, not too long? -> not applicable
- [ ] Are catch blocks catching precise Exceptions only (no catch all)? -> not applicable
- [ ] Have you used the correct file header copyright comment? -> not applicable
- [ ] Have you set the correct year in the headers of new files? -> not applicable

## Tests

- [ ] Are there unit-tests? -> not applicable
- [ ] Are there integration tests (or at least a jira to tackle these)? -> not applicable
