### PR TITLE
FUSETOOLS-2558 - Avoid NPE

### DIFF
--- a/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/util/KarafUtils.java
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/util/KarafUtils.java
@@ -326,10 +326,12 @@ public class KarafUtils {
 	
 	public static String stripParametersFromSymbolicName(String symbolicName) {
 		String resVal = symbolicName;
-		// sometimes parameters are added to the symbolic name - we should ignore them
-		int paramIdx = symbolicName.indexOf(';');
-		if (paramIdx != -1) {
-			resVal = symbolicName.substring(0, paramIdx);
+		if (symbolicName != null) {
+			// sometimes parameters are added to the symbolic name - we should ignore them
+			int paramIdx = symbolicName.indexOf(';');
+			if (paramIdx != -1) {
+				resVal = symbolicName.substring(0, paramIdx);
+			}
 		}
 		return resVal;
 	}


### PR DESCRIPTION
when adding functionality of Stripping Parameters in FUSETOOLS-2228 , it
removed the support of "null" symbolic name. Don't know how to reproduce
it and in which case it occurs exactly but at least we avoid NPE and
come back to previous behavior.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [x] Did you use the Jira Issue number in the commit comments?
- [x] Did you set meaningful commit comments on each commit?
- [x] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [x] Is there no duplicated code?
- [x] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?

## Legal

- [x] Have you used the correct file header copyright comment?
- [x] Have you used the correct year in the headers of new files?

