### PR TITLE
Don't close all perspective to speed up test execution

### DIFF
--- a/core/tests/org.fusesource.ide.camel.tests.util/src/org/fusesource/ide/camel/test/util/editor/AbstractCamelEditorIT.java
+++ b/core/tests/org.fusesource.ide.camel.tests.util/src/org/fusesource/ide/camel/test/util/editor/AbstractCamelEditorIT.java
@@ -59,7 +59,6 @@ public class AbstractCamelEditorIT {
 		IWorkbenchPart welcomePage = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActivePart();
 		welcomePage.dispose();
 		page.closeAllEditors(false);
-		page.closeAllPerspectives(false, false);
 		PlatformUI.getWorkbench().showPerspective(FusePerspective.ID, page.getWorkbenchWindow());
 		safeRunnableIgnoreErrorStateBeforeTests = SafeRunnable.getIgnoreErrors();
 		SafeRunnable.setIgnoreErrors(false);


### PR DESCRIPTION
don't need to close all perspectives, just need to have the Fuse one
opened. On my machine, it saves 450ms per test, and it affects 99 tests.
It should save 50"

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments? --> minor improvement fixed on the fly, do we want to create a Jira for it? (the answer can be yes, in this case I will create it) 
- [x] Did you set meaningful commit comments on each commit?
- [x] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [x] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too? --> non-applicable

## Maintainability

- [x] Are all Sonar reported issues fixed or can they be ignored?
- [x] Is there no duplicated code?
- [x] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests? --> non-applicable, it is touching an integration test
- [x] Are there integration tests (or at least a jira to tackle these)?

## Legal

- [x] Have you used the correct file header copyright comment?
- [x] Have you used the correct year in the headers of new files?

