### PR TITLE
FUSETOOLS-2713 - replaced deprecated maven call in syndesis integration test

### DIFF
--- a/syndesis/tests/org.fusesource.ide.syndesis.extension.ui.tests.integration/src/main/java/org/fusesource/ide/syndesis/extensions/tests/integration/wizards/SyndesisExtensionProjectCreatorRunnableIT.java
+++ b/syndesis/tests/org.fusesource.ide.syndesis.extension.ui.tests.integration/src/main/java/org/fusesource/ide/syndesis/extensions/tests/integration/wizards/SyndesisExtensionProjectCreatorRunnableIT.java
@@ -24,7 +24,6 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionResult;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -135,7 +134,7 @@ public abstract class SyndesisExtensionProjectCreatorRunnableIT extends Abstract
 		checkNoValidationWarning();
 		additionalChecks(project);
 		
-		launchBuild(project, new NullProgressMonitor());
+		launchBuild(new NullProgressMonitor());
 	}
 
 	private void waitForValidationThreads() throws InterruptedException {
@@ -227,8 +226,8 @@ public abstract class SyndesisExtensionProjectCreatorRunnableIT extends Abstract
 		assertThat(editor.isDirty()).as("A newly created project should not have dirty editor.").isFalse();
 	}
 	
-    protected void launchBuild(IProject project, IProgressMonitor monitor) throws CoreException {
-    	SubMonitor subMonitor = SubMonitor.convert(monitor, 10);
+	protected void launchBuild(IProgressMonitor monitor) throws CoreException {
+		SubMonitor subMonitor = SubMonitor.convert(monitor, 10);
 		MavenExecutionResult result = MavenPlugin.getMaven().createExecutionContext().execute(new ExecuteProjectBuildM2ECallable(), subMonitor.split(10));
 		buildFinished = true;
 		buildOK = !result.hasExceptions();

--- a/syndesis/tests/org.fusesource.ide.syndesis.extension.ui.tests.integration/src/main/java/org/fusesource/ide/syndesis/extensions/tests/integration/wizards/SyndesisExtensionProjectCreatorRunnableIT.java
+++ b/syndesis/tests/org.fusesource.ide.syndesis.extension.ui.tests.integration/src/main/java/org/fusesource/ide/syndesis/extensions/tests/integration/wizards/SyndesisExtensionProjectCreatorRunnableIT.java
@@ -19,6 +19,7 @@ import java.util.function.Predicate;
 
 import javax.management.MalformedObjectNameException;
 
+import org.apache.maven.Maven;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionResult;
 import org.eclipse.core.resources.IFile;
@@ -28,10 +29,13 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.embedder.ICallable;
 import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.embedder.IMavenExecutionContext;
+import org.eclipse.m2e.core.internal.embedder.MavenImpl;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorInput;
@@ -223,14 +227,9 @@ public abstract class SyndesisExtensionProjectCreatorRunnableIT extends Abstract
 		assertThat(editor.isDirty()).as("A newly created project should not have dirty editor.").isFalse();
 	}
 	
-    protected void launchBuild(IProject project, IProgressMonitor monitor) throws CoreException, InterruptedException, IOException, MalformedObjectNameException {
-		IMaven maven = MavenPlugin.getMaven();
-		IMavenExecutionContext executionContext = maven.createExecutionContext();
-		MavenExecutionRequest executionRequest = executionContext.getExecutionRequest();
-		executionRequest.setPom(project.getFile("pom.xml").getLocation().toFile());
-		executionRequest.setGoals(Arrays.asList("clean", "verify"));
-		
-		MavenExecutionResult result = maven.execute(executionRequest, monitor);
+    protected void launchBuild(IProject project, IProgressMonitor monitor) throws CoreException {
+    	SubMonitor subMonitor = SubMonitor.convert(monitor, 10);
+		MavenExecutionResult result = MavenPlugin.getMaven().createExecutionContext().execute(new ExecuteProjectBuildM2ECallable(), subMonitor.split(10));
 		buildFinished = true;
 		buildOK = !result.hasExceptions();
 		for (Throwable t : result.getExceptions()) {
@@ -238,4 +237,15 @@ public abstract class SyndesisExtensionProjectCreatorRunnableIT extends Abstract
 		}
 		assertThat(buildOK).isTrue();
 	}
+    
+    final class ExecuteProjectBuildM2ECallable implements ICallable<MavenExecutionResult> {
+    	@Override
+    	public MavenExecutionResult call(IMavenExecutionContext context, IProgressMonitor monitor) throws CoreException {
+			MavenExecutionRequest executionRequest = context.getExecutionRequest();
+			executionRequest.setPom(project.getFile("pom.xml").getLocation().toFile());
+			executionRequest.setGoals(Arrays.asList("clean", "verify"));
+			final IMaven maven = MavenPlugin.getMaven();
+			return ((MavenImpl)maven).lookupComponent(Maven.class).execute(executionRequest);
+    	}
+    }
 }


### PR DESCRIPTION
Original PR is #1226 

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

