### PR TITLE
FUSETOOLS-2338 - Remove API baseline

### DIFF
--- a/core/plugins/org.fusesource.ide.help/.project
+++ b/core/plugins/org.fusesource.ide.help/.project
@@ -21,11 +21,6 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.pde.api.tools.apiAnalysisBuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
 			<name>org.sonarlint.eclipse.core.sonarlintBuilder</name>
 			<arguments>
 			</arguments>
@@ -34,6 +29,5 @@
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
API baseline is not used for Fuse Tooling project, remove the builder
from the only plugin that is invoking it.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [x] Did you use the Jira Issue number in the commit comments?
- [x] Did you set meaningful commit comments on each commit?
- [x] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [x] Did the CI job report a successful build?
- [x] Is the non-happy path working, too?

## Maintainability

- [x] Are all Sonar reported issues fixed or can they be ignored?
- [x] Is there no duplicated code?
- [x] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests? --> not applicable
- [ ] Are there integration tests (or at least a jira to tackle these)? --> not applicable

## Legal

- [x] Have you used the correct file header copyright comment?
- [x] Have you used the correct year in the headers of new files?

