### PR TITLE
FUSETOOLS-2399 - Create Decoration asynchronously

### DIFF
--- a/core/plugins/org.fusesource.ide.foundation.ui/src/org/fusesource/ide/foundation/ui/util/ControlDecorationHelper.java
+++ b/core/plugins/org.fusesource.ide.foundation.ui/src/org/fusesource/ide/foundation/ui/util/ControlDecorationHelper.java
@@ -15,6 +15,7 @@ import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
 
 public class ControlDecorationHelper {
 
@@ -23,11 +24,19 @@ public class ControlDecorationHelper {
 		if (control != null) {
 			decoration = new ControlDecoration(control, SWT.BOTTOM | SWT.LEFT);
 			Image image = FieldDecorationRegistry.getDefault().getFieldDecoration(FieldDecorationRegistry.DEC_INFORMATION).getImage();
-			decoration.setImage(image);
+			setImageAsynchronuously(decoration, image);
 			decoration.setShowOnlyOnFocus(true);
 			decoration.setDescriptionText(informationText);
 		}
 		return decoration;
+	}
+
+	private void setImageAsynchronuously(final ControlDecoration decoration, final Image image) {
+		Display.getDefault().asyncExec(() -> {
+			if (!Widgets.isDisposed(decoration.getControl())) {
+				decoration.setImage(image);
+			}
+		});
 	}
 	
 	public ControlDecoration addErrorToControl(Control control, String errorMessage) {
@@ -35,7 +44,7 @@ public class ControlDecorationHelper {
 		if (control != null) {
 			decoration = new ControlDecoration(control, SWT.TOP | SWT.LEFT);
 			Image image = FieldDecorationRegistry.getDefault().getFieldDecoration(FieldDecorationRegistry.DEC_ERROR).getImage();
-			decoration.setImage(image);
+			setImageAsynchronuously(decoration, image);
 			decoration.setShowOnlyOnFocus(false);
 			decoration.setDescriptionText(errorMessage);
 		}


### PR DESCRIPTION
- several of them are showing up only on focus anyway
- several of them are part of a different tab and so not displayed
immediately
- on my machine it helps to display ftp advanced tab from 4s to 500ms
without noticing any delay on display

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [x] Did you use the Jira Issue number in the commit comments?
- [x] Did you set meaningful commit comments on each commit?
- [x] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [x] Did the CI job report a successful build?
- [x] Is the non-happy path working, too?

## Maintainability

- [x] Are all Sonar reported issues fixed or can they be ignored?
- [x] Is there no duplicated code?
- [x] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)? --> no specific test, code is covered several times by existing tests

## Legal

- [x] Have you used the correct file header copyright comment?
- [x] Have you used the correct year in the headers of new files?

