### PR TITLE
FUSETOOLS-1317 - Publish module on start of Karaf/Fuse servers

### DIFF
--- a/servers/plugins/org.fusesource.ide.server.fuse.core/plugin.xml
+++ b/servers/plugins/org.fusesource.ide.server.fuse.core/plugin.xml
@@ -80,7 +80,7 @@
            runtimeTypeId="org.fusesource.ide.fuseesb.runtime.60"
            startTimeout="90000"
            stopTimeout="45000"
-           startBeforePublish="false" 
+           startBeforePublish="true" 
            supportsRemoteHosts="false">
      </serverType>
      <serverType
@@ -97,7 +97,7 @@
            runtimeTypeId="org.fusesource.ide.fuseesb.runtime.61"
            startTimeout="90000"
            stopTimeout="45000"
-           startBeforePublish="false" 
+           startBeforePublish="true" 
            supportsRemoteHosts="false">
      </serverType>
      <serverType
@@ -114,7 +114,7 @@
            runtimeTypeId="org.fusesource.ide.fuseesb.runtime.62"
            startTimeout="90000"
            stopTimeout="45000"
-           startBeforePublish="false" 
+           startBeforePublish="true" 
            supportsRemoteHosts="false">
      </serverType>
      <serverType
@@ -131,7 +131,7 @@
            runtimeTypeId="org.fusesource.ide.fuseesb.runtime.63"
            startTimeout="90000"
            stopTimeout="45000"
-           startBeforePublish="false" 
+           startBeforePublish="true" 
            supportsRemoteHosts="false">
      </serverType>
      <serverType
@@ -148,7 +148,7 @@
            runtimeTypeId="org.fusesource.ide.fuseesb.runtime.70"
            startTimeout="90000"
            stopTimeout="45000"
-           startBeforePublish="false" 
+           startBeforePublish="true" 
            supportsRemoteHosts="false">
      </serverType>
   </extension>

--- a/servers/plugins/org.fusesource.ide.server.karaf.core/plugin.xml
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/plugin.xml
@@ -107,7 +107,7 @@
            runtimeTypeId="org.fusesource.ide.karaf.runtime.22"
            startTimeout="90000"
            stopTimeout="45000"
-           startBeforePublish="false" 
+           startBeforePublish="true" 
            supportsRemoteHosts="false">
      </serverType>
      <serverType
@@ -124,7 +124,7 @@
            runtimeTypeId="org.fusesource.ide.karaf.runtime.23"
            startTimeout="90000"
            stopTimeout="45000"
-           startBeforePublish="false" 
+           startBeforePublish="true" 
            supportsRemoteHosts="false">
      </serverType>
      <serverType
@@ -141,7 +141,7 @@
            runtimeTypeId="org.fusesource.ide.karaf.runtime.24"
            startTimeout="90000"
            stopTimeout="45000"
-           startBeforePublish="false" 
+           startBeforePublish="true" 
            supportsRemoteHosts="false">
      </serverType>
      <serverType
@@ -158,7 +158,7 @@
            runtimeTypeId="org.fusesource.ide.karaf.runtime.30"
            startTimeout="90000"
            stopTimeout="45000"
-           startBeforePublish="false" 
+           startBeforePublish="true" 
            supportsRemoteHosts="false">
      </serverType>
      <serverType
@@ -175,7 +175,7 @@
            runtimeTypeId="org.fusesource.ide.karaf.runtime.40"
            startTimeout="90000"
            stopTimeout="45000"
-           startBeforePublish="false" 
+           startBeforePublish="true" 
            supportsRemoteHosts="false">
      </serverType>
      <serverType
@@ -192,7 +192,7 @@
            runtimeTypeId="org.fusesource.ide.karaf.runtime.41"
            startTimeout="90000"
            stopTimeout="45000"
-           startBeforePublish="false" 
+           startBeforePublish="true" 
            supportsRemoteHosts="false">
      </serverType>
   </extension>

--- a/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/server/subsystems/Karaf2xPublishController.java
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/server/subsystems/Karaf2xPublishController.java
@@ -11,8 +11,6 @@
 package org.fusesource.ide.server.karaf.core.server.subsystems;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
 
 import org.apache.maven.project.MavenProject;
 import org.eclipse.core.resources.IProject;
@@ -50,21 +48,11 @@ import org.jboss.ide.eclipse.as.wtp.core.util.ServerModelUtilities;
  * @author lhein
  */
 public class Karaf2xPublishController extends AbstractSubsystemController implements IPublishController, IPrimaryPublishController  {
-	private static final List<String> GOALS = Arrays.asList("package");
 	
 	protected IPublishBehaviour publisher2 = new KarafJMXPublisher();
 	
-	/*
-	 * (non-Javadoc)
-	 * @see org.jboss.ide.eclipse.as.wtp.core.server.behavior.IPublishController#canPublish()
-	 */
 	@Override
 	public IStatus canPublish() {
-		// workaround for bug in WTP (https://bugs.eclipse.org/bugs/show_bug.cgi?id=465141), should be removed once its fixed upstream
-		// also switch back startBeforePublish=true to all kind of servers in the plugin.xml files
-		if (getServer().getServerState() != Server.STATE_STARTED){
-			return Status.CANCEL_STATUS;
-		}
 		return Status.OK_STATUS;
 	}
 


### PR DESCRIPTION
As bug has been fixed upstream
https://bugs.eclipse.org/bugs/show_bug.cgi?id=465141, the workaround can
be removed
https://github.com/jbosstools/jbosstools-fuse/commit/cc1b1e2137d327db4d0774345528e39e1bb46544

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [x] Did you use the Jira Issue number in the commit comments?
- [x] Did you set meaningful commit comments on each commit?
- [x] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [x] Did the CI job report a successful build?
- [x] Is the non-happy path working, too?

## Maintainability

- [x] Are all Sonar reported issues fixed or can they be ignored?
- [x] Is there no duplicated code?
- [x] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests? --> an integration issue
- [ ] Are there integration tests (or at least a jira to tackle these)? --> Server tests are handled by QE, created https://issues.jboss.org/browse/FUSETOOLS-2774

## Legal

- [x] Have you used the correct file header copyright comment?
- [x] Have you used the correct year in the headers of new files?

