### PR TITLE
FUSETOOLS-2833 - create 2 profiles splitting tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,9 +285,6 @@
 					</systemProperties>
 					<useUIThread>true</useUIThread>
 					<useUIHarness>true</useUIHarness>
-					<includes>
-						<include>**/*IT.class</include>
-					</includes>
 					<argLine>${tycho.testArgLine} -XX:+HeapDumpOnOutOfMemoryError ${platformSystemProperties} ${systemProperties} ${moduleProperties} -Dusage_reporting_enabled=false -Dorg.jboss.tools.vpe.loadxulrunner=false -Dgroovy.grape.report.downloads=true -Divy.message.logger.level=4 -Dsun.net.client.defaultConnectTimeout=30000 -Dsun.net.client.defaultReadTimeout=30000</argLine>
 					<osgiDataDirectory>${project.basedir}/target/work sp@cé</osgiDataDirectory>
 				</configuration>
@@ -305,6 +302,71 @@
 	</dependencies>
 
 	<profiles>
+		<profile>
+			<id>default-integration-test</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-surefire-plugin</artifactId>
+						<version>${tychoVersion}</version>
+						<configuration>
+							<includes>
+								<include>**/*IT.class</include>
+							</includes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>without-templates-integration-test</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-surefire-plugin</artifactId>
+						<version>${tychoVersion}</version>
+						<configuration>
+							<includes>
+								<include>**/*IT.class</include>
+							</includes>
+							<excludes>
+								<exclude>**/FuseIntegrationProjectCreatorRunnable*IT.class</exclude>
+							</excludes>
+							<failIfNoTests>false</failIfNoTests>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>templates-integration-test</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-surefire-plugin</artifactId>
+						<version>${tychoVersion}</version>
+						<configuration>
+							<includes>
+								<include>**/FuseIntegrationProjectCreatorRunnable*IT.class</include>
+							</includes>
+							<failIfNoTests>false</failIfNoTests>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 		<profile>
 			<id>quality</id>
 			<activation>


### PR DESCRIPTION
set Templates integration tests in a separated profile to allow to
launch in different jobs as they are failing a lot on CI currently 

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

