### PR TITLE
FUSETOOLS-2866 - Update image name from jboss-fuse-7 to fuse7

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse7/.settings/fusetooling/Deploy %%%PLACEHOLDER_PROJECTNAME%%% on OpenShift.launch
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse7/.settings/fusetooling/Deploy %%%PLACEHOLDER_PROJECTNAME%%% on OpenShift.launch
@@ -12,6 +12,6 @@
 <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
 <stringAttribute key="M2_USER_SETTINGS" value=""/>
 <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dkubernetes.master=https://192.168.99.128:8443&#13;&#10;-Dkubernetes.namespace=test&#13;&#10;-Dkubernetes.auth.basic.username=developer&#13;&#10;-Dkubernetes.auth.basic.password=developer&#13;&#10;-Dfabric8.mode=openshift&#13;&#10;-Dkubernetes.trust.certificates=true&#13;&#10;-Dfabric8.build.strategy=s2i&#13;&#10;-Dkubernetes.auth.tryServiceAccount=false&#13;&#10;-Dfabric8.generator.from=registry.access.redhat.com/jboss-fuse-7/fuse-java-openshift&#13;&#10;-Dfabric8.generator.fromMode=docker&#13;&#10;-Dkubernetes.auth.tryKubeConfig=false"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dkubernetes.master=https://192.168.99.128:8443&#13;&#10;-Dkubernetes.namespace=test&#13;&#10;-Dkubernetes.auth.basic.username=developer&#13;&#10;-Dkubernetes.auth.basic.password=developer&#13;&#10;-Dfabric8.mode=openshift&#13;&#10;-Dkubernetes.trust.certificates=true&#13;&#10;-Dfabric8.build.strategy=s2i&#13;&#10;-Dkubernetes.auth.tryServiceAccount=false&#13;&#10;-Dfabric8.generator.from=registry.access.redhat.com/fuse7/fuse-java-openshift&#13;&#10;-Dfabric8.generator.fromMode=docker&#13;&#10;-Dkubernetes.auth.tryKubeConfig=false"/>
 <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:%%%PLACEHOLDER_PROJECTNAME%%%}"/>
 </launchConfiguration>


### PR DESCRIPTION
change registry.access.redhat.com/jboss-fuse-7/fuse-java-openshift to registry.access.redhat.com/fuse7/fuse-java-openshift which will be the name for Fuse 7
/!\ /!\ it is not possible to test it before the GA! (not even internally) /!\ /!\

currently only tech previews are pushed with a different strange name.
It means that:
- before GA, users will need to modify the value but "ok, this is tech preview"
- after GA everything is fine!

the other solution would be to provide tech preview name, it would mean:
- before GA, it will work
- after GA, the wrong image will be used and so no assurance that it will work or not


# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [x] Did you use the Jira Issue number in the commit comments?
- [x] Did you set meaningful commit comments on each commit?
- [x] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [x] Is the non-happy path working, too?

## Maintainability

- [x] Are all Sonar reported issues fixed or can they be ignored?
- [x] Is there no duplicated code?
- [x] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [x] Have you used the correct file header copyright comment?
- [x] Have you used the correct year in the headers of new files?

