### PR TITLE
FUSETOOLS-2899 - avoid showing error for numeric values using default

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/l10n/Messages.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/l10n/Messages.java
@@ -22,6 +22,7 @@ public class Messages extends NLS {
 	public static String RequiredPropertyValidator_messageMissingParameter;
 	public static String eipWithoutChild;
 	public static String validationSameComponentIdAndComponentDefinitionId;
+	public static String numberValidatorMessageErrorWithoutArgument;
 
 	static {
 		// initialize resource bundle

--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/l10n/messages.properties
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/l10n/messages.properties
@@ -2,3 +2,4 @@ NumberValidator_messageError=The parameter {0} requires a numeric value.
 RequiredPropertyValidator_messageMissingParameter=Parameter {0} is a mandatory field and cannot be empty.
 eipWithoutChild=This component must have a child
 validationSameComponentIdAndComponentDefinitionId=Parameter {0} cannot have the same value ({1}) as its component definition scheme.
+numberValidatorMessageErrorWithoutArgument=Invalid numeric value

--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/model/NumberValidator.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/model/NumberValidator.java
@@ -19,6 +19,7 @@ import org.fusesource.ide.camel.model.service.core.util.CamelComponentUtils;
 import org.fusesource.ide.camel.model.service.core.util.PropertiesUtils;
 import org.fusesource.ide.camel.validation.l10n.Messages;
 import org.fusesource.ide.foundation.core.util.CamelPlaceHolderUtil;
+import org.fusesource.ide.foundation.core.util.Strings;
 
 /**
  * @author Aurelien Pupier
@@ -37,7 +38,7 @@ public class NumberValidator implements IValidator {
 
 	@Override
 	public IStatus validate(Object value) {
-		if (isNonEmpty(value)
+		if (Strings.isNonEmptyAndNotOnlySpaces(value)
 				&& !new CamelPlaceHolderUtil().isPlaceHolder(value)
 				&& (parameter == null || CamelComponentUtils.isNumberProperty(parameter))) {
 			try {
@@ -53,7 +54,4 @@ public class NumberValidator implements IValidator {
 		return ValidationStatus.ok();
 	}
 
-	protected boolean isNonEmpty(Object value) {
-		return value != null && value.toString().trim().length() > 0;
-	}
 }

--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/model/NumberValidator.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/model/NumberValidator.java
@@ -30,22 +30,35 @@ public class NumberValidator implements IValidator {
 	public NumberValidator(Parameter parameter) {
 		this.parameter = parameter;
 	}
+	
+	public NumberValidator() {
+	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.core.databinding.validation.IValidator#validate(java.lang.Object)
-	 */
 	@Override
 	public IStatus validate(Object value) {
-		// only check non-empty fields
-		if (CamelComponentUtils.isNumberProperty(parameter)) {
-			if (value != null && value.toString().trim().length() > 0) {
-				try {
-					PropertiesUtils.validateDuration(value.toString());
-				} catch (IllegalArgumentException ex) {
+		if (isNonEmpty(value)
+				&& !isPlaceHolder(value)
+				&& (parameter == null || CamelComponentUtils.isNumberProperty(parameter))) {
+			try {
+				PropertiesUtils.validateDuration(value.toString());
+			} catch (IllegalArgumentException ex) {
+				if (parameter != null) {
 					return ValidationStatus.error(NLS.bind(Messages.NumberValidator_messageError, parameter.getName()), ex);
+				} else {
+					return ValidationStatus.error("Invalid numeric value");
 				}
 			}
 		}
 		return ValidationStatus.ok();
+	}
+
+	private boolean isPlaceHolder(Object value) {
+		return value != null && value instanceof String
+				&& ((String) value).startsWith("{{")
+				&& ((String) value).endsWith("}}");
+	}
+
+	protected boolean isNonEmpty(Object value) {
+		return value != null && value.toString().trim().length() > 0;
 	}
 }

--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/model/NumberValidator.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/model/NumberValidator.java
@@ -18,6 +18,7 @@ import org.fusesource.ide.camel.model.service.core.catalog.Parameter;
 import org.fusesource.ide.camel.model.service.core.util.CamelComponentUtils;
 import org.fusesource.ide.camel.model.service.core.util.PropertiesUtils;
 import org.fusesource.ide.camel.validation.l10n.Messages;
+import org.fusesource.ide.foundation.core.util.CamelPlaceHolderUtil;
 
 /**
  * @author Aurelien Pupier
@@ -37,7 +38,7 @@ public class NumberValidator implements IValidator {
 	@Override
 	public IStatus validate(Object value) {
 		if (isNonEmpty(value)
-				&& !isPlaceHolder(value)
+				&& !new CamelPlaceHolderUtil().isPlaceHolder(value)
 				&& (parameter == null || CamelComponentUtils.isNumberProperty(parameter))) {
 			try {
 				PropertiesUtils.validateDuration(value.toString());
@@ -45,17 +46,11 @@ public class NumberValidator implements IValidator {
 				if (parameter != null) {
 					return ValidationStatus.error(NLS.bind(Messages.NumberValidator_messageError, parameter.getName()), ex);
 				} else {
-					return ValidationStatus.error("Invalid numeric value");
+					return ValidationStatus.error(Messages.numberValidatorMessageErrorWithoutArgument);
 				}
 			}
 		}
 		return ValidationStatus.ok();
-	}
-
-	private boolean isPlaceHolder(Object value) {
-		return value != null && value instanceof String
-				&& ((String) value).startsWith("{{")
-				&& ((String) value).endsWith("}}");
 	}
 
 	protected boolean isNonEmpty(Object value) {

--- a/core/plugins/org.fusesource.ide.foundation.core/src/org/fusesource/ide/foundation/core/util/CamelPlaceHolderUtil.java
+++ b/core/plugins/org.fusesource.ide.foundation.core/src/org/fusesource/ide/foundation/core/util/CamelPlaceHolderUtil.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.fusesource.ide.foundation.core.util;
+
+public class CamelPlaceHolderUtil {
+
+	public boolean isPlaceHolder(Object value) {
+		return value != null
+				&& value instanceof String
+				&& ((String) value).startsWith("{{")
+				&& ((String) value).endsWith("}}");
+	}
+	
+}

--- a/core/plugins/org.fusesource.ide.foundation.core/src/org/fusesource/ide/foundation/core/util/Strings.java
+++ b/core/plugins/org.fusesource.ide.foundation.core/src/org/fusesource/ide/foundation/core/util/Strings.java
@@ -32,6 +32,10 @@ public class Strings {
         return text == null || text.length() == 0;
     }
     
+	public static boolean isNonEmptyAndNotOnlySpaces(Object value) {
+		return value != null && value.toString().trim().length() > 0;
+	}
+    
     public static String splitCamelCase(String text) {
         StringBuilder buffer = new StringBuilder();
         char last = 'A';

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/src/org/fusesource/ide/camel/validation/model/NumberValidatorIT.java
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/src/org/fusesource/ide/camel/validation/model/NumberValidatorIT.java
@@ -10,7 +10,8 @@
  ******************************************************************************/
 package org.fusesource.ide.camel.validation.model;
 
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.fusesource.ide.camel.model.service.core.catalog.Parameter;
 import org.junit.Test;
 
@@ -20,28 +21,59 @@ public class NumberValidatorIT {
 	public void testValidateOK() throws Exception {
 		final Parameter parameter = new Parameter();
 		parameter.setJavaType(Integer.class.getName());
-		Assertions.assertThat(new NumberValidator(parameter).validate("12").isOK()).isTrue();
+		assertThat(new NumberValidator(parameter).validate("12").isOK()).isTrue();
+	}
+	
+	@Test
+	public void testValidateOKWithEmptyConstructor() throws Exception {
+		assertThat(new NumberValidator().validate("12").isOK()).isTrue();
 	}
 
 	@Test
 	public void testValidateKO() throws Exception {
 		final Parameter parameter = new Parameter();
 		parameter.setJavaType(Integer.class.getName());
-		Assertions.assertThat(new NumberValidator(parameter).validate("test").isOK()).isFalse();
+		assertThat(new NumberValidator(parameter).validate("test").isOK()).isFalse();
+	}
+	
+	@Test
+	public void testValidateKOWithEmptyConstructor() throws Exception {
+		final Parameter parameter = new Parameter();
+		parameter.setJavaType(Integer.class.getName());
+		assertThat(new NumberValidator().validate("test").isOK()).isFalse();
 	}
 
 	@Test
 	public void testIgnoreNotInteger() throws Exception {
 		final Parameter parameter = new Parameter();
 		parameter.setJavaType(String.class.getName());
-		Assertions.assertThat(new NumberValidator(parameter).validate("test").isOK()).isTrue();
+		assertThat(new NumberValidator(parameter).validate("test").isOK()).isTrue();
 	}
 
 	@Test
 	public void testIgnoreEmptyValues() throws Exception {
 		final Parameter parameter = new Parameter();
 		parameter.setJavaType(Integer.class.getName());
-		Assertions.assertThat(new NumberValidator(parameter).validate("").isOK()).isTrue();
+		assertThat(new NumberValidator(parameter).validate("").isOK()).isTrue();
+	}
+	
+	@Test
+	public void testIgnoreNullValues() throws Exception {
+		final Parameter parameter = new Parameter();
+		parameter.setJavaType(Integer.class.getName());
+		assertThat(new NumberValidator(parameter).validate(null).isOK()).isTrue();
+	}
+	
+	@Test
+	public void testIgnoreNullValuesWithEmptyConstructor() throws Exception {
+		assertThat(new NumberValidator().validate(null).isOK()).isTrue();
+	}
+	
+	@Test
+	public void testIgnorePropertyPlaceholder() throws Exception {
+		final Parameter parameter = new Parameter();
+		parameter.setJavaType(Integer.class.getName());
+		assertThat(new NumberValidator(parameter).validate("{{placeholder}}").isOK()).isTrue();
 	}
 
 }

--- a/core/tests/org.fusesource.ide.foundation.core.test/src/test/java/org/fusesource/ide/foundation/core/util/CamelPlaceHolderUtilTest.java
+++ b/core/tests/org.fusesource.ide.foundation.core.test/src/test/java/org/fusesource/ide/foundation/core/util/CamelPlaceHolderUtilTest.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.fusesource.ide.foundation.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class CamelPlaceHolderUtilTest {
+	
+	CamelPlaceHolderUtil camelPlaceHolderUtil = new CamelPlaceHolderUtil();
+	
+	@Test
+	public void testEmptyValueIsNotPlaceHolder() throws Exception {
+		assertThat(camelPlaceHolderUtil.isPlaceHolder("")).isFalse();
+	}
+	
+	@Test
+	public void testNullValueIsNotPlaceHolder() throws Exception {
+		assertThat(camelPlaceHolderUtil.isPlaceHolder("")).isFalse();
+	}
+	
+	@Test
+	public void testNormalValueIsNotPlaceHolder() throws Exception {
+		assertThat(camelPlaceHolderUtil.isPlaceHolder("aValue")).isFalse();
+	}
+	
+	@Test
+	public void testPlaceHolderValueIsPlaceHolder() throws Exception {
+		assertThat(camelPlaceHolderUtil.isPlaceHolder("{{a placeholder}}")).isTrue();
+	}
+
+}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/creators/modifylisteners/number/AbstractNumberModifyListener.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/creators/modifylisteners/number/AbstractNumberModifyListener.java
@@ -10,13 +10,13 @@
  ******************************************************************************/ 
 package org.fusesource.ide.camel.editor.properties.creators.modifylisteners.number;
 
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.widgets.Text;
 import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
-import org.fusesource.ide.camel.model.service.core.util.PropertiesUtils;
-import org.fusesource.ide.foundation.core.util.Strings;
+import org.fusesource.ide.camel.validation.model.NumberValidator;
 
 /**
  * @author Aurelien Pupier
@@ -27,9 +27,6 @@ public abstract class AbstractNumberModifyListener implements ModifyListener {
 	protected AbstractCamelModelElement camelModelElement;
 	protected String parameterName;
 
-	/**
-	 * @param numberParameterPropertyUICreator
-	 */
 	public AbstractNumberModifyListener(AbstractCamelModelElement camelModelElement, String parameterName) {
 		this.camelModelElement = camelModelElement;
 		this.parameterName = parameterName;
@@ -39,13 +36,11 @@ public abstract class AbstractNumberModifyListener implements ModifyListener {
 	public void modifyText(ModifyEvent e) {
 	    Text txt = (Text)e.getSource();
 	    String val = txt.getText();
-	    try {
-	    	if (val != null && !Strings.isEmpty(val)) {
-	    		PropertiesUtils.validateDuration(val);
-	    	}
+	    IStatus status = new NumberValidator().validate(val);
+	    if (status.isOK()) {
 	    	txt.setBackground(ColorConstants.white);
-			updateModel(txt.getText());
-	    } catch (IllegalArgumentException ex) {
+	    	updateModel(txt.getText());
+	    } else {
 	    	txt.setBackground(ColorConstants.red);
 	    }
 	}


### PR DESCRIPTION
placeholders

not handling all kind of placeholders and the updated ones but at least
holding the default one with {{ and }}

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [x] Did you use the Jira Issue number in the commit comments?
- [x] Did you set meaningful commit comments on each commit?
- [x] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [x] Did the CI job report a successful build?
- [x] Is the non-happy path working, too?

## Maintainability

- [x] Are all Sonar reported issues fixed or can they be ignored?
- [x] Is there no duplicated code?
- [x] Are method-/class-/variable-names meaningful?

## Tests

- [x] Are there unit-tests?
- [x] Are there integration tests (or at least a jira to tackle these)?
- [x] Do we need a new UI test?

## Legal

- [x] Have you used the correct file header copyright comment?
- [x] Have you used the correct year in the headers of new files?

