### PR TITLE
FUSETOOLS-2924 - workaround upstream inconsistency for zipFile

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/catalog/cache/CamelModel.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/catalog/cache/CamelModel.java
@@ -93,6 +93,16 @@ public class CamelModel {
 	}
 	
 	/**
+	 * adds a dataformat to the cache (overwrites existing dataformat with same name)
+	 * 
+	 * @param overriddenName
+	 * @param dataformat	the dataformat to add
+	 */
+	public void addDataFormat(String overriddenName, DataFormat dataformat) {
+		dataformats.put(overriddenName, dataformat);
+	}
+	
+	/**
 	 * returns the dataformat with the given name if existing
 	 * 
 	 * @param name	the name of the dataformat (for instance "base64")
@@ -211,4 +221,5 @@ public class CamelModel {
 	public void setLanguages(Map<String, Language> languages) {
 		this.languages.putAll(languages);
 	}
+
 }

--- a/core/plugins/org.fusesource.ide.camel.model.service.impl/src/org/fusesource/ide/camel/model/service/internal/CamelModelPatcher.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.impl/src/org/fusesource/ide/camel/model/service/internal/CamelModelPatcher.java
@@ -19,6 +19,7 @@ import org.apache.camel.catalog.CamelCatalog;
 import org.fusesource.ide.camel.model.service.core.catalog.Parameter;
 import org.fusesource.ide.camel.model.service.core.catalog.cache.CamelModel;
 import org.fusesource.ide.camel.model.service.core.catalog.components.Component;
+import org.fusesource.ide.camel.model.service.core.catalog.dataformats.DataFormat;
 import org.fusesource.ide.camel.model.service.core.catalog.eips.Eip;
 import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
@@ -45,6 +46,14 @@ public class CamelModelPatcher {
 		applyMissingWhenChildDefinitionForChoice(loadedModel);
 		applyFixesToComponentsSyntax(loadedModel);
 		applyMissingCamelContextEip(camelVersion, loadedModel);
+		applyZipFileDataformatNameInconsistencyWorkaround(loadedModel);
+	}
+
+	private static void applyZipFileDataformatNameInconsistencyWorkaround(CamelModel loadedModel) {
+		DataFormat zipfileDataformat = loadedModel.getDataFormat("zipfile");
+		if (zipfileDataformat != null) {
+			loadedModel.addDataFormat("zipFile", zipfileDataformat);
+		}
 	}
 
 	private static void applyMissingCamelContextEip(String camelVersion, CamelModel loadedModel) {


### PR DESCRIPTION
dataformat

different case, it is called zipFile in some places and zipfile in some
others.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [x] Did you use the Jira Issue number in the commit comments?
- [x] Did you set meaningful commit comments on each commit?
- [x] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [x] Did the CI job report a successful build?
- [x] Is the non-happy path working, too?

## Maintainability

- [x] Are all Sonar reported issues fixed or can they be ignored?
- [x] Is there no duplicated code?
- [x] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [x] Have you used the correct file header copyright comment?
- [x] Have you used the correct year in the headers of new files?

