### PR TITLE
FUSETOOLS-2955 - Fix camel version databinding when selecting a Runtime

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/FuseIntegrationProjectWizardRuntimeAndCamelPage.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/pages/FuseIntegrationProjectWizardRuntimeAndCamelPage.java
@@ -95,6 +95,7 @@ public class FuseIntegrationProjectWizardRuntimeAndCamelPage extends WizardPage 
 	private IObservableValue<FuseDeploymentPlatform> environmentPlatformObservable;
 	private IObservableValue<FuseRuntimeKind> environmentRuntimeObservable;
 	private ISideEffect sideEffect;
+	private WritableList<String> camelVersionsProposed;
 	
 	public FuseIntegrationProjectWizardRuntimeAndCamelPage(EnvironmentData environment) {
 		super(Messages.newProjectWizardRuntimePageName);
@@ -155,7 +156,8 @@ public class FuseIntegrationProjectWizardRuntimeAndCamelPage extends WizardPage 
 		GridData camelComboData = new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1);
 		camelVersionCombo.setLayoutData(camelComboData);
 		camelVersionComboViewer.setContentProvider(new ObservableListContentProvider());
-		camelVersionComboViewer.setInput(new WritableList<String>(new ArrayList<String>(CamelCatalogUtils.getAllCamelCatalogVersions()), String.class));
+		camelVersionsProposed = new WritableList<>(new ArrayList<String>(CamelCatalogUtils.getAllCamelCatalogVersions()), String.class);
+		camelVersionComboViewer.setInput(camelVersionsProposed);
 		camelVersionComboViewer.setSelection(new StructuredSelection(CamelCatalogUtils.getLatestCamelVersion()));
 		camelVersionCombo.setToolTipText(Messages.newProjectWizardRuntimePageCamelDescription);
 		camelVersionCombo.addSelectionListener(new SelectionAdapter() {
@@ -381,12 +383,10 @@ public class FuseIntegrationProjectWizardRuntimeAndCamelPage extends WizardPage 
 		if (UNKNOWN_CAMEL_VERSION.equals(runtimeCamelVersion)) {
 			camelVersionComboViewer.getCombo().setEnabled(true);
 		} else {
-			if(((List<?>)camelVersionComboViewer.getInput()).contains(runtimeCamelVersion)) {
-				camelVersionComboViewer.setSelection(new StructuredSelection(runtimeCamelVersion));
-			} else {
-				camelVersionComboViewer.setSelection(StructuredSelection.EMPTY);
-				camelVersionComboViewer.getCombo().setText(runtimeCamelVersion);
+			if(!((List<?>)camelVersionComboViewer.getInput()).contains(runtimeCamelVersion)) {
+				camelVersionsProposed.add(runtimeCamelVersion);
 			}
+			camelVersionComboViewer.setSelection(new StructuredSelection(runtimeCamelVersion));
 		}		
 	}
 


### PR DESCRIPTION
instance

- now the data model of EnvironmentData is correctly updated
- the version is added to the list of proposed version until next open
of the wizard (i think that it makes sense as the version is an
"available" version as it was extracted from an existing Runtime
instance)

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [x] Did you use the Jira Issue number in the commit comments?
- [x] Did you set meaningful commit comments on each commit?
- [x] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [x] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [x] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [x] Do we need a new UI test?

## Legal

- [x] Have you used the correct file header copyright comment?
- [x] Have you used the correct year in the headers of new files?

