### PR TITLE
FUSETOOLS-2965 - use Fuse 7 version for wsdl2rest dependencies

### DIFF
--- a/editor/plugins/org.fusesource.ide.wsdl2rest/pom.xml
+++ b/editor/plugins/org.fusesource.ide.wsdl2rest/pom.xml
@@ -15,16 +15,16 @@
 	<name>Red Hat Fuse Tooling :: Camel Editor :: Plugins :: Wsdl2Rest Implementation</name>
 
 	<properties>
-		<version.apache.camel>2.21.0.fuse-000069</version.apache.camel>
-		<version.apache.cxf>3.1.11.fuse-000226</version.apache.cxf>
-		<version.apache.velocity>1.7</version.apache.velocity>
-		<version.args4j>2.33</version.args4j>
+		<version.apache.camel>2.21.0.fuse-000077-redhat-1</version.apache.camel>
+		<version.apache.cxf>3.1.11.fuse-000243-redhat-1</version.apache.cxf>
+		<version.apache.velocity>1.7.0.redhat-5</version.apache.velocity>
+		<version.args4j>2.0.31.redhat-1</version.args4j>
 		<version.javaparser>2.5.1</version.javaparser>
-		<version.javax.ws.rs.api>2.1</version.javax.ws.rs.api>
-		<version.wsdl4j>1.6.3</version.wsdl4j>
-		<version.commons.lang>2.4</version.commons.lang>
+		<version.javax.ws.rs.api>2.0.1.redhat-1</version.javax.ws.rs.api>
+		<version.wsdl4j>1.6.3.redhat-2</version.wsdl4j>
+		<version.commons.lang>2.6.0.redhat-6</version.commons.lang>
 		<version.commons.validator>1.6</version.commons.validator>
-		<version.wsdl2rest>0.7.0.fuse-000044</version.wsdl2rest>
+		<version.wsdl2rest>0.7.0.fuse-000052-redhat-1</version.wsdl2rest>
 	</properties>
 
 	<dependencyManagement>
@@ -179,21 +179,5 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<!-- These "staging" repositories are "saved". They can be removed when moving to a publicly available release -->
-	<repositories>
-		<repository>
-			<id>Saved staging repo for cxf</id>
-			<url>https://repository.jboss.org/nexus/content/repositories/fusesource_releases_external-9109/</url>
-		</repository>
-		<repository>
-			<id>Saved staging repo for camel</id>
-			<url>https://repository.jboss.org/nexus/content/repositories/fusesource_releases_external-9110/</url>
-		</repository>
-		<repository>
-			<id>Saved staging repo for WSDL2rest</id>
-			<url>https://repository.jboss.org/nexus/content/repositories/fusesource_releases_external-9111/</url>
-		</repository>
-	</repositories>
 
 </project>


### PR DESCRIPTION
note: some dependencies are missing from Fuse 7 repository so keep using
community one for these ones

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [x] Did you use the Jira Issue number in the commit comments?
- [x] Did you set meaningful commit comments on each commit?
- [x] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [x] Did the CI job report a successful build?
- [x] Is the non-happy path working, too?

## Maintainability

- [x] Are all Sonar reported issues fixed or can they be ignored?
- [x] Is there no duplicated code?
- [x] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [x] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [x] Have you used the correct file header copyright comment?
- [x] Have you used the correct year in the headers of new files?

