### PR TITLE
FUSETOOLS-2985 - embed Fuse 7 Camel Catalog;...

### DIFF
--- a/core/features/org.fusesource.ide.core.feature/feature.xml
+++ b/core/features/org.fusesource.ide.core.feature/feature.xml
@@ -83,13 +83,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.fusesource.ide.camel.model.service.impl"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.fusesource.ide.cheatsheets"
          download-size="0"
          install-size="0"
@@ -145,32 +138,11 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.fusesource.ide.camel.model.service.impl.v2151redhat621216"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.fusesource.ide.camel.model.service.impl.v2170redhat630343"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.fusesource.ide.camel.model.service.impl.v2181redhat000021"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.fusesource.ide.camel.model.service.impl.v2203"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+   <plugin id="org.fusesource.ide.camel.model.service.impl" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.fusesource.ide.camel.model.service.impl.v2151redhat621216" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.fusesource.ide.camel.model.service.impl.v2170redhat630343" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.fusesource.ide.camel.model.service.impl.v2181redhat000021" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.fusesource.ide.camel.model.service.impl.v2203" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.fusesource.ide.camel.model.service.impl.v2210fuse000077redhat1" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
 
 </feature>


### PR DESCRIPTION
FUSETOOLS-2985 - embed Fuse 7 Camel Catalog; add missing plugin org.fusesource.ide.camel.model.service.impl.v2210fuse000077redhat1 to core/features/org.fusesource.ide.core.feature/feature.xml so it's on the update site and can be found by org.fusesource.ide.camel.editor.tests.integration as part of the jbosstools-build-sites.aggregate.coretests-site_master build

Signed-off-by: nickboldt <nboldt@redhat.com>