### PR TITLE
FUSETOOLS-3063 - dummy modification to workaround timestamp provider

### DIFF
--- a/editor/plugins/org.fusesource.ide.wsdl2rest/META-INF/MANIFEST.MF
+++ b/editor/plugins/org.fusesource.ide.wsdl2rest/META-INF/MANIFEST.MF
@@ -85,3 +85,4 @@ Export-Package: org.apache.commons.validator.routines;x-friends:="org.fusesource
  org.jboss.fuse.wsdl2rest.impl.service;x-friends:="org.fusesource.ide.wsdl2rest.ui",
  org.jboss.fuse.wsdl2rest.impl.writer;x-friends:="org.fusesource.ide.wsdl2rest.ui",
  org.jboss.fuse.wsdl2rest.util;x-friends:="org.fusesource.ide.wsdl2rest.ui"
+Bundle-Vendor: Red Hat

--- a/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/runtime/classpath/KarafProjectRuntimeClasspathProvider.java
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/runtime/classpath/KarafProjectRuntimeClasspathProvider.java
@@ -72,7 +72,7 @@ public class KarafProjectRuntimeClasspathProvider extends RuntimeClasspathProvid
 		if (installPath == null)
 			return new IClasspathEntry[0];
 
-		List<IClasspathEntry> list = new ArrayList<IClasspathEntry>();
+		List<IClasspathEntry> list = new ArrayList<>();
 
 		String runtimeId = runtime.getRuntimeType().getId();
 		if (runtimeId.indexOf(".fuseesb.runtime.") != -1 || runtimeId.indexOf(".karaf.runtime.") != -1) {

--- a/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/runtime/integration/AbstractStacksDownloadRuntimesProvider.java
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/runtime/integration/AbstractStacksDownloadRuntimesProvider.java
@@ -64,7 +64,7 @@ public abstract class AbstractStacksDownloadRuntimesProvider implements IDownloa
 	private synchronized ArrayList<DownloadRuntime> loadDownloadableRuntimes(IProgressMonitor monitor) {
 		monitor.beginTask(Messages.LoadRemoteRuntimes, 200);
 		Stacks[] stacksArr = getStacks(new SubProgressMonitor(monitor, 100));
-		ArrayList<DownloadRuntime> all = new ArrayList<DownloadRuntime>();
+		ArrayList<DownloadRuntime> all = new ArrayList<>();
 		monitor.beginTask(Messages.CreateDownloadRuntimes, stacksArr.length * 100);		
 		for( int i = 0; i < stacksArr.length && !monitor.isCanceled(); i++ ) {
 			IProgressMonitor inner = new SubProgressMonitor(monitor, 100);

--- a/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/server/SourcePathComputerDelegate.java
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/server/SourcePathComputerDelegate.java
@@ -42,7 +42,7 @@ public class SourcePathComputerDelegate implements ISourcePathComputerDelegate  
 	public ISourceContainer[] computeSourceContainers(ILaunchConfiguration configuration, IProgressMonitor monitor) throws CoreException {
 		
 		IRuntimeClasspathEntry[] unresolvedEntries = JavaRuntime.computeUnresolvedSourceLookupPath(configuration);
-		List<FolderSourceContainer> sourcefolderList = new ArrayList<FolderSourceContainer>();
+		List<FolderSourceContainer> sourcefolderList = new ArrayList<>();
 		
 		IServer server =  ServerUtil.getServer(configuration);
 		
@@ -54,7 +54,7 @@ public class SourcePathComputerDelegate implements ISourcePathComputerDelegate  
 		if (modules == null)
 			return null;
 		
-		List<IJavaProject> javaProjectList = new ArrayList<IJavaProject>();
+		List<IJavaProject> javaProjectList = new ArrayList<>();
 		
 		processModules(sourcefolderList, modules, javaProjectList, server,monitor);
 

--- a/servers/plugins/org.fusesource.ide.server.karaf.ui/src/org/fusesource/ide/server/karaf/ui/SshConnector.java
+++ b/servers/plugins/org.fusesource.ide.server.karaf.ui/src/org/fusesource/ide/server/karaf/ui/SshConnector.java
@@ -30,7 +30,7 @@ import org.jboss.ide.eclipse.as.wtp.core.server.behavior.IControllableServerBeha
  */
 public class SshConnector  {
 
-	private static HashMap<IServer, SshConnector> connectors = new HashMap<IServer, SshConnector>();
+	private static HashMap<IServer, SshConnector> connectors = new HashMap<>();
 	
 	private int port;
 	private String host;

--- a/servers/plugins/org.fusesource.ide.server.karaf.ui/src/org/fusesource/ide/server/karaf/ui/launch/KarafLaunchConfigTabGroup.java
+++ b/servers/plugins/org.fusesource.ide.server.karaf.ui/src/org/fusesource/ide/server/karaf/ui/launch/KarafLaunchConfigTabGroup.java
@@ -31,7 +31,7 @@ public class KarafLaunchConfigTabGroup extends
 
 	@Override
 	public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
-		List<ILaunchConfigurationTab> tabs = new ArrayList<ILaunchConfigurationTab>(5);
+		List<ILaunchConfigurationTab> tabs = new ArrayList<>(5);
 		
 //		tabs.add(new ServerLaunchConfigurationTab(IKarafServerDelegate.SERVER_IDS_SUPPORTED));
 		tabs.add(new JavaArgumentsTab());

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/wizards/TransformTestWizardPage.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/wizards/TransformTestWizardPage.java
@@ -295,7 +295,7 @@ public class TransformTestWizardPage extends NewTypeWizardPage {
                 }
 
             } else {
-                IFolder folder = javaProject.getProject().getFolder("src/test/java"); //$NON-NLS-1$
+                IFolder folder = javaProject.getProject().getFolder(TEST_SOURCE_FOLDER); //$NON-NLS-1$
                 if (!folder.exists()) {
                     IFolder srcFolder = javaProject.getProject().getFolder("src"); //$NON-NLS-1$
                     if (!srcFolder.exists()) {


### PR DESCRIPTION
configuration limitation

the timestamp provider is configured to ignore pom.xml modifications but
last modification was affecting only pom.xml 

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

