### PR TITLE
FUSETOOLS-3149 - fix wrong validation for Double and Float

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/CamelComponentUtils.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/CamelComponentUtils.java
@@ -138,11 +138,27 @@ public final class CamelComponentUtils {
 
 	public static boolean isNumberProperty(Parameter p) {
 		final String javaType = p.getJavaType();
-		return p.getChoice() == null && ("int".equalsIgnoreCase(javaType) || "Integer".equalsIgnoreCase(javaType)
-				|| "java.lang.Integer".equalsIgnoreCase(javaType) || "long".equalsIgnoreCase(javaType)
-				|| "java.lang.Long".equalsIgnoreCase(javaType) || "double".equalsIgnoreCase(javaType)
-				|| "java.lang.Double".equalsIgnoreCase(javaType) || "float".equalsIgnoreCase(javaType)
-				|| "java.lang.Float".equalsIgnoreCase(javaType) || "Number".equalsIgnoreCase(javaType));
+		return p.getChoice() == null && (isIntegerTypeProperty(javaType)
+				|| isLongTypeProperty(javaType)
+				|| isDoubleTypeProperty(javaType)
+				|| isFloatTypeProperty(javaType)
+				|| "Number".equalsIgnoreCase(javaType));
+	}
+
+	public static boolean isLongTypeProperty(final String javaType) {
+		return "long".equalsIgnoreCase(javaType) || "java.lang.Long".equalsIgnoreCase(javaType);
+	}
+
+	public static boolean isDoubleTypeProperty(final String javaType) {
+		return "double".equalsIgnoreCase(javaType) || "java.lang.Double".equalsIgnoreCase(javaType);
+	}
+
+	public static boolean isFloatTypeProperty(final String javaType) {
+		return "float".equalsIgnoreCase(javaType) || "java.lang.Float".equalsIgnoreCase(javaType);
+	}
+
+	public static boolean isIntegerTypeProperty(final String javaType) {
+		return "int".equalsIgnoreCase(javaType) || "Integer".equalsIgnoreCase(javaType) || "java.lang.Integer".equalsIgnoreCase(javaType);
 	}
 
 	public static boolean isChoiceProperty(Parameter p) {

--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/l10n/Messages.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/l10n/Messages.java
@@ -18,11 +18,12 @@ import org.eclipse.osgi.util.NLS;
  */
 public class Messages extends NLS {
 	private static final String BUNDLE_NAME = "org.fusesource.ide.camel.validation.l10n.messages"; //$NON-NLS-1$
-	public static String NumberValidator_messageError;
+	public static String numberValidatorMessageError;
 	public static String RequiredPropertyValidator_messageMissingParameter;
 	public static String eipWithoutChild;
 	public static String validationSameComponentIdAndComponentDefinitionId;
-	public static String numberValidatorMessageErrorWithoutArgument;
+	public static String numberValidatorMessageErrorForDouble;
+	public static String numberValidatorMessageErrorForFloat;
 
 	static {
 		// initialize resource bundle

--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/l10n/messages.properties
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/l10n/messages.properties
@@ -1,5 +1,6 @@
-NumberValidator_messageError=The parameter {0} requires a numeric value.
+numberValidatorMessageError=The parameter {0} contains an invalid numeric value.
 RequiredPropertyValidator_messageMissingParameter=Parameter {0} is a mandatory field and cannot be empty.
 eipWithoutChild=This component must have a child
 validationSameComponentIdAndComponentDefinitionId=Parameter {0} cannot have the same value ({1}) as its component definition scheme.
-numberValidatorMessageErrorWithoutArgument=Invalid numeric value
+numberValidatorMessageErrorForDouble=The parameter {0} contains an invalid numeric value. It must be a value in the range of java.lang.Double.
+numberValidatorMessageErrorForFloat=The parameter {0} contains an invalid numeric value. It must be a value in the range of java.lang.Float.

--- a/core/tests/org.fusesource.ide.camel.validation.tests.integration/src/org/fusesource/ide/camel/validation/model/NumberValidatorIT.java
+++ b/core/tests/org.fusesource.ide.camel.validation.tests.integration/src/org/fusesource/ide/camel/validation/model/NumberValidatorIT.java
@@ -18,62 +18,45 @@ import org.junit.Test;
 public class NumberValidatorIT {
 
 	@Test
-	public void testValidateOK() throws Exception {
-		final Parameter parameter = new Parameter();
-		parameter.setJavaType(Integer.class.getName());
-		assertThat(new NumberValidator(parameter).validate("12").isOK()).isTrue();
+	public void testValidateIntegerOK() throws Exception {
+		testOk(Integer.class.getName(), "12");
 	}
 	
 	@Test
-	public void testValidateOKWithEmptyConstructor() throws Exception {
-		assertThat(new NumberValidator().validate("12").isOK()).isTrue();
+	public void testValidateIntegerDurationOK() throws Exception {
+		testOk(Integer.class.getName(), "12s");
+	}
+	
+	@Test
+	public void testValidateIntegerKO() throws Exception {
+		testKo(Integer.class.getName(), "test");
 	}
 
 	@Test
-	public void testValidateKO() throws Exception {
-		final Parameter parameter = new Parameter();
-		parameter.setJavaType(Integer.class.getName());
-		assertThat(new NumberValidator(parameter).validate("test").isOK()).isFalse();
+	public void testValidateOKLong() throws Exception {
+		testOk(Long.class.getName(), "0");
 	}
 	
 	@Test
-	public void testValidateKOWithEmptyConstructor() throws Exception {
-		final Parameter parameter = new Parameter();
-		parameter.setJavaType(Integer.class.getName());
-		assertThat(new NumberValidator().validate("test").isOK()).isFalse();
+	public void testValidateOKDurationLong() throws Exception {
+		testOk(Long.class.getName(), "0s");
+	}
+	
+	@Test
+	public void testValidateKOLong() throws Exception {
+		testKo(Long.class.getName(), "0.1");
 	}
 
-	@Test
-	public void testIgnoreNotInteger() throws Exception {
+	private void testOk(String javaType, String value) {
 		final Parameter parameter = new Parameter();
-		parameter.setJavaType(String.class.getName());
-		assertThat(new NumberValidator(parameter).validate("test").isOK()).isTrue();
-	}
-
-	@Test
-	public void testIgnoreEmptyValues() throws Exception {
-		final Parameter parameter = new Parameter();
-		parameter.setJavaType(Integer.class.getName());
-		assertThat(new NumberValidator(parameter).validate("").isOK()).isTrue();
+		parameter.setJavaType(javaType);
+		assertThat(new NumberValidator(parameter).validate(value).isOK()).isTrue();
 	}
 	
-	@Test
-	public void testIgnoreNullValues() throws Exception {
+	private void testKo(String typeName, String value) {
 		final Parameter parameter = new Parameter();
-		parameter.setJavaType(Integer.class.getName());
-		assertThat(new NumberValidator(parameter).validate(null).isOK()).isTrue();
-	}
-	
-	@Test
-	public void testIgnoreNullValuesWithEmptyConstructor() throws Exception {
-		assertThat(new NumberValidator().validate(null).isOK()).isTrue();
-	}
-	
-	@Test
-	public void testIgnorePropertyPlaceholder() throws Exception {
-		final Parameter parameter = new Parameter();
-		parameter.setJavaType(Integer.class.getName());
-		assertThat(new NumberValidator(parameter).validate("{{placeholder}}").isOK()).isTrue();
+		parameter.setJavaType(typeName);
+		assertThat(new NumberValidator(parameter).validate(value).isOK()).isFalse();
 	}
 
 }

--- a/core/tests/org.fusesource.ide.camel.validation.tests/src/test/java/org/fusesource/ide/camel/validation/model/NumberValidatorTest.java
+++ b/core/tests/org.fusesource.ide.camel.validation.tests/src/test/java/org/fusesource/ide/camel/validation/model/NumberValidatorTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.fusesource.ide.camel.validation.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.fusesource.ide.camel.model.service.core.catalog.Parameter;
+import org.junit.Test;
+
+public class NumberValidatorTest {
+
+	@Test
+	public void testIgnoreNotNumber() throws Exception {
+		testOk(String.class.getName(), "test");
+	}
+
+	@Test
+	public void testIgnoreEmptyValues() throws Exception {
+		testOk(Integer.class.getName(), "");
+	}
+	
+	@Test
+	public void testIgnoreNullValues() throws Exception {
+		testOk(Integer.class.getName(), null);
+	}
+	
+	@Test
+	public void testIgnorePropertyPlaceholder() throws Exception {
+		testOk(Integer.class.getName(), "{{placeholder}}");
+	}
+	
+	@Test
+	public void testValidateOKDouble() throws Exception {
+		testOk(Double.class.getName(), "0.1");
+	}
+	
+	@Test
+	public void testValidateKODouble() throws Exception {
+		testKo(Double.class.getName(), "test");
+	}
+	
+	@Test
+	public void testValidateOKFloat() throws Exception {
+		testOk(Float.class.getName(), "0.1");
+	}
+	
+	@Test
+	public void testValidateKOFloat() throws Exception {
+		testKo(Float.class.getName(), "test");
+	}
+	
+	private void testKo(String typeName, String value) {
+		final Parameter parameter = new Parameter();
+		parameter.setJavaType(typeName);
+		assertThat(new NumberValidator(parameter).validate(value).isOK()).isFalse();
+	}
+	
+	private void testOk(String javaType, String value) {
+		final Parameter parameter = new Parameter();
+		parameter.setJavaType(javaType);
+		assertThat(new NumberValidator(parameter).validate(value).isOK()).isTrue();
+	}
+
+}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/creators/advanced/NumberParameterPropertyUICreatorForAdvanced.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/creators/advanced/NumberParameterPropertyUICreatorForAdvanced.java
@@ -27,7 +27,7 @@ import org.fusesource.ide.camel.model.service.core.util.PropertiesUtils;
  */
 public class NumberParameterPropertyUICreatorForAdvanced extends AbstractNumberParameterPropertyUICreator {
 
-	public NumberParameterPropertyUICreatorForAdvanced(DataBindingContext dbc, IObservableMap modelMap, Eip eip, AbstractCamelModelElement camelModelElement, Parameter parameter,
+	public NumberParameterPropertyUICreatorForAdvanced(DataBindingContext dbc, IObservableMap<?,?> modelMap, Eip eip, AbstractCamelModelElement camelModelElement, Parameter parameter,
 			Composite parent, TabbedPropertySheetWidgetFactory widgetFactory) {
 		super(dbc, modelMap, eip, camelModelElement, parameter, parent, widgetFactory, new NumberModifyListenerForAdvanced(camelModelElement, parameter, modelMap));
 	}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/creators/details/NumberParameterPropertyUICreatorForDetails.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/creators/details/NumberParameterPropertyUICreatorForDetails.java
@@ -26,9 +26,9 @@ import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelEleme
  */
 public class NumberParameterPropertyUICreatorForDetails extends AbstractNumberParameterPropertyUICreator {
 
-	public NumberParameterPropertyUICreatorForDetails(DataBindingContext dbc, IObservableMap modelMap, Eip eip, AbstractCamelModelElement camelModelElement, Parameter parameter,
+	public NumberParameterPropertyUICreatorForDetails(DataBindingContext dbc, IObservableMap<?,?> modelMap, Eip eip, AbstractCamelModelElement camelModelElement, Parameter parameter,
 			Composite parent, TabbedPropertySheetWidgetFactory widgetFactory) {
-		super(dbc, modelMap, eip, camelModelElement, parameter, parent, widgetFactory, new NumberModifyListenerForDetails(camelModelElement, parameter.getName()));
+		super(dbc, modelMap, eip, camelModelElement, parameter, parent, widgetFactory, new NumberModifyListenerForDetails(camelModelElement, parameter));
 	}
 
 }

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/creators/modifylisteners/number/AbstractNumberModifyListener.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/creators/modifylisteners/number/AbstractNumberModifyListener.java
@@ -15,6 +15,7 @@ import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.widgets.Text;
+import org.fusesource.ide.camel.model.service.core.catalog.Parameter;
 import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.validation.model.NumberValidator;
 
@@ -25,18 +26,18 @@ import org.fusesource.ide.camel.validation.model.NumberValidator;
 public abstract class AbstractNumberModifyListener implements ModifyListener {
 
 	protected AbstractCamelModelElement camelModelElement;
-	protected String parameterName;
+	protected Parameter parameter;
 
-	public AbstractNumberModifyListener(AbstractCamelModelElement camelModelElement, String parameterName) {
+	public AbstractNumberModifyListener(AbstractCamelModelElement camelModelElement, Parameter parameter) {
 		this.camelModelElement = camelModelElement;
-		this.parameterName = parameterName;
+		this.parameter = parameter;
 	}
-
+	
 	@Override
 	public void modifyText(ModifyEvent e) {
 	    Text txt = (Text)e.getSource();
 	    String val = txt.getText();
-	    IStatus status = new NumberValidator().validate(val);
+	    IStatus status = new NumberValidator(parameter).validate(val);
 	    if (status.isOK()) {
 	    	txt.setBackground(ColorConstants.white);
 	    	updateModel(txt.getText());
@@ -44,6 +45,6 @@ public abstract class AbstractNumberModifyListener implements ModifyListener {
 	    	txt.setBackground(ColorConstants.red);
 	    }
 	}
-	
+
 	protected abstract void updateModel(String newValue);
 }

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/creators/modifylisteners/number/NumberModifyListenerForAdvanced.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/creators/modifylisteners/number/NumberModifyListenerForAdvanced.java
@@ -22,17 +22,15 @@ import org.fusesource.ide.camel.model.service.core.util.PropertiesUtils;
  */
 public class NumberModifyListenerForAdvanced extends AbstractNumberModifyListener {
 
-	private Parameter parameter;
 	private Component component;
-	private IObservableMap modelMap;
+	private IObservableMap<?,?> modelMap;
 
-	public NumberModifyListenerForAdvanced(AbstractCamelModelElement camelModelElement, Parameter parameter, IObservableMap modelMap) {
-		super(camelModelElement, parameter.getName());
-		this.parameter = parameter;
+	public NumberModifyListenerForAdvanced(AbstractCamelModelElement camelModelElement, Parameter parameter, IObservableMap<?,?> modelMap) {
+		super(camelModelElement, parameter);
 		this.component = PropertiesUtils.getComponentFor(camelModelElement);
 		this.modelMap = modelMap;
 	}
-
+	
 	@Override
 	protected void updateModel(String newValue) {
 		PropertiesUtils.updateURIParams(camelModelElement, parameter, newValue, component, modelMap);

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/creators/modifylisteners/number/NumberModifyListenerForDetails.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/creators/modifylisteners/number/NumberModifyListenerForDetails.java
@@ -10,6 +10,7 @@
  ******************************************************************************/ 
 package org.fusesource.ide.camel.editor.properties.creators.modifylisteners.number;
 
+import org.fusesource.ide.camel.model.service.core.catalog.Parameter;
 import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
@@ -18,13 +19,13 @@ import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelEleme
  */
 public class NumberModifyListenerForDetails extends AbstractNumberModifyListener {
 
-	public NumberModifyListenerForDetails(AbstractCamelModelElement camelModelElement, String parameterName) {
-		super(camelModelElement, parameterName);
+	public NumberModifyListenerForDetails(AbstractCamelModelElement camelModelElement, Parameter parameter) {
+		super(camelModelElement, parameter);
 	}
 
 	@Override
 	protected void updateModel(String newValue) {
-		camelModelElement.setParameter(parameterName, newValue);
+		camelModelElement.setParameter(parameter.getName(), newValue);
 	}
 
 }


### PR DESCRIPTION
for Duration, there is no information in catalog, it seems to be only
possible with Integer and Long type which are decimal so we are better
for Double and Float than before and same precision for
Long/Integer/Duration

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [x] Did you use the Jira Issue number in the commit comments?
- [x] Did you set meaningful commit comments on each commit?
- [x] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [x] Did the CI job report a successful build?
- [x] Is the non-happy path working, too?

## Maintainability

- [x] Are all Sonar reported issues fixed or can they be ignored?
- [x] Is there no duplicated code?
- [x] Are method-/class-/variable-names meaningful?

## Tests

- [x] Are there unit-tests?
- [x] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [x] Have you used the correct file header copyright comment?
- [x] Have you used the correct year in the headers of new files?

