### PR TITLE
FUSETOOLS-3097 - Avoid resetting elements if they are at the correct

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/AbstractCamelModelElement.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/AbstractCamelModelElement.java
@@ -27,6 +27,7 @@ import org.fusesource.ide.camel.model.service.core.catalog.cache.CamelCatalogCac
 import org.fusesource.ide.camel.model.service.core.catalog.cache.CamelModel;
 import org.fusesource.ide.camel.model.service.core.catalog.eips.Eip;
 import org.fusesource.ide.camel.model.service.core.internal.CamelModelServiceCoreActivator;
+import org.fusesource.ide.camel.model.service.core.util.XMLUtils;
 import org.fusesource.ide.foundation.core.util.CamelUtils;
 import org.fusesource.ide.foundation.core.util.Strings;
 import org.fusesource.ide.preferences.PreferenceManager;
@@ -234,40 +235,6 @@ public abstract class AbstractCamelModelElement {
 			if (n.getNodeType() == Node.ELEMENT_NODE) {
 				return n;
 			}
-		}
-		return null;
-	}
-
-	/**
-	 * gets the previous element node if existing
-	 *
-	 * @param node
-	 * @return the previous element or null
-	 */
-	protected Node getPreviousNode(Node node) {
-		Node n = node.getPreviousSibling();
-		while (n != null) {
-			if (n.getNodeType() == Node.ELEMENT_NODE) {
-				return n;
-			}
-			n = n.getPreviousSibling();
-		}
-		return null;
-	}
-
-	/**
-	 * returns the next element node
-	 *
-	 * @param node
-	 * @return the next element node or null
-	 */
-	protected Node getNextNode(Node node) {
-		Node n = node.getNextSibling();
-		while (n != null) {
-			if (n.getNodeType() == Node.ELEMENT_NODE) {
-				return n;
-			}
-			n = n.getNextSibling();
 		}
 		return null;
 	}
@@ -539,7 +506,7 @@ public abstract class AbstractCamelModelElement {
 		// now move the node directly after inputElement in DOM tree
 		if (inputElement != null) {
 			Node inputNode = inputElement.getXmlNode();
-			Node insertPosNode = getNextNode(inputNode);
+			Node insertPosNode = new XMLUtils().getNextNode(inputNode);
 			if (insertPosNode != null && !getXmlNode().isEqualNode(insertPosNode)) {
 				inputNode.getParentNode().insertBefore(getXmlNode(), insertPosNode);
 			}

--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelElementConnection.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelElementConnection.java
@@ -10,6 +10,7 @@
  ******************************************************************************/ 
 package org.fusesource.ide.camel.model.service.core.model;
 
+import org.fusesource.ide.camel.model.service.core.util.XMLUtils;
 import org.w3c.dom.Node;
 
 /**
@@ -76,13 +77,14 @@ public class CamelElementConnection extends AbstractCamelModelElement {
 		if (source == null) {
 			if (other.source != null)
 				return false;
-		} else if (!source.equals(other.source))
+		} else if (!source.equals(other.source)) {
 			return false;
-		if (target == null) {
+		} if (target == null) {
 			if (other.target != null)
 				return false;
-		} else if (!target.equals(other.target))
+		} else if (!target.equals(other.target)) {
 			return false;
+		}
 		return true;
 	}
 
@@ -128,7 +130,10 @@ public class CamelElementConnection extends AbstractCamelModelElement {
 			// rearrange DOM elements
 			Node sourceNode = source.getXmlNode();
 			Node targetNode = target.getXmlNode();
-			source.getParent().getXmlNode().insertBefore(sourceNode, targetNode);
+			Node currentNextNodeOfSourceNode = new XMLUtils().getNextNode(sourceNode);
+			if (currentNextNodeOfSourceNode == null || !currentNextNodeOfSourceNode.equals(targetNode)) {
+				source.getParent().getXmlNode().insertBefore(sourceNode, targetNode);
+			}
 			
 			isConnected = true;
 		}
@@ -144,7 +149,7 @@ public class CamelElementConnection extends AbstractCamelModelElement {
 	 * @param newTarget
 	 *            a new target endpoint for this connection (non null)
 	 * @throws IllegalArgumentException
-	 *             if any of the paramers are null or newSource == newTarget
+	 *             if any of the parameters are null or newSource == newTarget
 	 */
 	public void reconnect(AbstractCamelModelElement newSource, AbstractCamelModelElement newTarget) {
 		if (newSource == null || newTarget == null || newSource == newTarget) {

--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/XMLUtils.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/XMLUtils.java
@@ -1,0 +1,34 @@
+/******************************************************************************* 
+ * Copyright (c) 2018 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.fusesource.ide.camel.model.service.core.util;
+
+import org.w3c.dom.Node;
+
+public class XMLUtils {
+	
+	/**
+	 * returns the next element node
+	 *
+	 * @param node
+	 * @return the next element node or null
+	 */
+	public Node getNextNode(Node node) {
+		Node n = node.getNextSibling();
+		while (n != null) {
+			if (n.getNodeType() == Node.ELEMENT_NODE) {
+				return n;
+			}
+			n = n.getNextSibling();
+		}
+		return null;
+	}
+
+}

--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/java/org/fusesource/ide/camel/model/service/core/tests/integration/core/io/CamelIOHandlerIT.java
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/java/org/fusesource/ide/camel/model/service/core/tests/integration/core/io/CamelIOHandlerIT.java
@@ -71,7 +71,8 @@ public class CamelIOHandlerIT {
 				"routes.xml",
 				"withMarshalCsvHeaders.xml",
 				"routeContext.xml",
-				"withCDATA.xml");
+				"withCDATA.xml",
+				"withComments.xml");
 		//@formatter:on
 	}
 

--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/java/org/fusesource/ide/camel/model/service/core/tests/integration/core/model/CamelElementConnectionIT.java
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/java/org/fusesource/ide/camel/model/service/core/tests/integration/core/model/CamelElementConnectionIT.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.fusesource.ide.camel.model.service.core.tests.integration.core.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.fusesource.ide.camel.model.service.core.io.CamelIOHandler;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.CamelElementConnection;
+import org.fusesource.ide.camel.model.service.core.model.CamelFile;
+import org.fusesource.ide.camel.model.service.core.tests.integration.core.io.CamelIOHandlerIT;
+import org.fusesource.ide.camel.model.service.core.tests.integration.core.io.FuseProject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class CamelElementConnectionIT {
+
+	@Rule
+	public TemporaryFolder testFolder = new TemporaryFolder();
+
+	@Rule
+	public FuseProject fuseProject = new FuseProject(CamelElementConnectionIT.class.getSimpleName());
+	
+	@Test
+	public void testReconnectionOfAlreadyConnectedElementDoesntModifyXML() throws IOException, CoreException {
+		String name = "withComments.xml";
+
+		InputStream inputStream = CamelIOHandlerIT.class.getClassLoader().getResourceAsStream("/" + name);
+
+		File baseFile = File.createTempFile("baseFile" + name, "xml");
+		Files.copy(inputStream, baseFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+		inputStream = CamelIOHandlerIT.class.getClassLoader().getResourceAsStream("/" + name);
+		IFile fileInProject = fuseProject.getProject().getFile(name);
+		fileInProject.create(inputStream, true, new NullProgressMonitor());
+
+		CamelFile model1 = new CamelIOHandler().loadCamelModel(fileInProject, new NullProgressMonitor());
+
+		assertThat(model1.getRouteContainer().getChildElements()).isNotEmpty();
+		
+		AbstractCamelModelElement route = model1.getRouteContainer().getChildElements().get(0);
+		AbstractCamelModelElement source = route.getChildElements().get(1);
+		AbstractCamelModelElement target = route.getChildElements().get(2);
+		
+		String initialXML = model1.getDocumentAsXML();
+		
+		new CamelElementConnection(source, target).reconnect(source, target);
+		
+		String xmlAfterReconnection = model1.getDocumentAsXML();
+		
+		assertThat(xmlAfterReconnection).isEqualTo(initialXML);
+		
+	}
+	
+}

--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/resources/withComments.xml
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/resources/withComments.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="              http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+    <!-- before camel context comment -->
+    <camelContext id="cbr-example-context" xmlns="http://camel.apache.org/schema/blueprint">
+        <!-- before route comment -->
+        <route id="cbr-route">
+            <!-- comment at first place inside route -->
+            <from id="_from1" uri="file:work/cbr/input"/>
+            <!-- test comment after first route element -->
+            <log id="_log1" message="Receiving order ${file:name}"/>
+            <!-- test comment before the last route element -->
+            <log id="_log5" message="Done processing ${file:name}"/>
+            <!-- test comment at last place inside route -->
+        </route>
+    </camelContext>
+</blueprint>


### PR DESCRIPTION
place

it avoids to mess up comments just by displaying diagram.
Please note that modification of the xml is still done in the graphical
which should not occur by design. it would be better to do it in Model
element directly.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

