### PR TITLE
FUSETOOLS-3173 - UI Tests - Adjust wait condition for 'Run As Local C…

### DIFF
--- a/uitests/plugins/org.jboss.tools.fuse.reddeer/src/org/jboss/tools/fuse/reddeer/projectexplorer/CamelProject.java
+++ b/uitests/plugins/org.jboss.tools.fuse.reddeer/src/org/jboss/tools/fuse/reddeer/projectexplorer/CamelProject.java
@@ -25,7 +25,6 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.reddeer.common.exception.WaitTimeoutExpiredException;
 import org.eclipse.reddeer.common.matcher.RegexMatcher;
 import org.eclipse.reddeer.common.util.XPathEvaluator;
 import org.eclipse.reddeer.common.wait.AbstractWait;
@@ -104,27 +103,8 @@ public class CamelProject {
 		} catch (CoreLayerException ex) {
 			new ContextMenuItem("Run As", "1 Local Camel Context").select();
 		}
-
-		ConsoleHasText camel = new ConsoleHasText("Starting Camel ...");
-		ConsoleHasText jetty = new ConsoleHasText("Started Jetty Server");
-		ConsoleHasText failure = new ConsoleHasText("BUILD FAILURE");
-		boolean started = false;
-		for (int i = 0; i < 300; i++) {
-			if (camel.test() || jetty.test()) {
-				started = true;
-				break;
-			}
-			if (failure.test()) {
-				break;
-			}
-			AbstractWait.sleep(TimePeriod.SHORT);
-		}
-		if (!started) {
-			new WaitTimeoutExpiredException("Console doesn't contains 'Starting Camel ...' or 'Started Jetty Server'");
-		}
-
 		AbstractWait.sleep(TimePeriod.DEFAULT);
-		new WaitUntil(new ConsoleHasText("started and consuming from"), TimePeriod.VERY_LONG);
+		new WaitUntil(new ConsoleHasText("started and consuming from"), TimePeriod.getCustom(600));
 	}
 
 	public void runCamelContextWithoutTests(String name) {


### PR DESCRIPTION
…amel Context'

SpringBoot examples does not contain "Starting Camel", therefore the wait condition cannot be fulfilled + produces a lot of log information

Signed-off-by: Tomáš Sedmík <tsedmik@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

