### PR TITLE
FUSETOOLS-3190 - use CamelFile method to have xml to save

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/io/CamelIOHandler.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/io/CamelIOHandler.java
@@ -13,17 +13,12 @@ package org.fusesource.ide.camel.model.service.core.io;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Result;
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
@@ -164,28 +159,9 @@ public class CamelIOHandler {
 	 * @param monitor
 	 */
 	public void saveCamelModel(CamelFile camelFile, File outputFile, IProgressMonitor monitor) {
-		if (this.document == null) {
-			this.document = createDocumentBuilder().newDocument();
-		}
-
+		String camelAsXml = camelFile.getDocumentAsXML();
 		try {
-			// now the real save logic
-			TransformerFactory tf = TransformerFactory.newInstance();
-			tf.setAttribute("indent-number", INDENTION_VALUE);
-
-			Transformer transformer = tf.newTransformer();
-
-			// Save vs. Save as
-			Result output = new StreamResult(outputFile);
-			Source input = new DOMSource(this.document);
-
-			transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-			transformer.setOutputProperty(OutputKeys.METHOD, "xml");
-			transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
-			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount",
-					Integer.toString(INDENTION_VALUE));
-			transformer.transform(input, output);
+			Files.copy(new ByteArrayInputStream(camelAsXml.getBytes(StandardCharsets.UTF_8)), outputFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
 		} catch (Exception ex) {
 			CamelModelServiceCoreActivator.pluginLog()
 					.logError("Unable to save the camel file to " + outputFile.getPath(), ex);


### PR DESCRIPTION
with java 11, the methods previously used with transformers is
introducing extra-lines on each lines which is breaking the field
containing the CDATA.

note that the saveAsCamelModel seems to be used only in test for real.
Other places referenced:
- Datatransformation, it is used only when the class field saveModel is
set to true which is never the case currently.
- CamelEditorPersistencyDiagram: currently not used, the saved is
intercepted at multieditor level, synchronizing the model with the
source tab and then saving from source tab.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

