### PR TITLE
FUSETOOLS-3218 - Not set unsupported Java 9+ VM argument when vm is 9+

### DIFF
--- a/servers/plugins/org.fusesource.ide.server.fuse.core/src/org/fusesource/ide/server/fuse/core/server/subsystems/Fuse6xStartupLaunchConfigurator.java
+++ b/servers/plugins/org.fusesource.ide.server.fuse.core/src/org/fusesource/ide/server/fuse/core/server/subsystems/Fuse6xStartupLaunchConfigurator.java
@@ -14,6 +14,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.wst.server.core.IServer;
 import org.fusesource.ide.foundation.core.util.Strings;
 import org.fusesource.ide.server.fuse.core.util.FuseToolingConstants;
+import org.fusesource.ide.server.karaf.core.runtime.IKarafRuntime;
 import org.fusesource.ide.server.karaf.core.server.subsystems.Karaf2xStartupLaunchConfigurator;
 
 /**
@@ -31,8 +32,8 @@ public class Fuse6xStartupLaunchConfigurator extends Karaf2xStartupLaunchConfigu
 	}
 	
 	@Override
-	public String getVMArguments(String karafInstallDir, String endorsedDirs, String extDirs) {
-		StringBuilder sb = new StringBuilder(super.getVMArguments(karafInstallDir, endorsedDirs, extDirs));
+	public String getVMArguments(String karafInstallDir, IKarafRuntime runtime, String endorsedDirs, String extDirs) {
+		StringBuilder sb = new StringBuilder(super.getVMArguments(karafInstallDir, runtime, endorsedDirs, extDirs));
 		sb.append(SPACE + "-XX:PermSize=16M -XX:MaxPermSize=128M");
 		return sb.toString();
 	}

--- a/servers/plugins/org.fusesource.ide.server.karaf.core/META-INF/MANIFEST.MF
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/META-INF/MANIFEST.MF
@@ -30,7 +30,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
  org.fusesource.ide.foundation.ui;bundle-version="10.0.0",
  org.jboss.ide.eclipse.as.classpath.core;bundle-version="3.1.1",
  org.eclipse.wst.common.project.facet.ui,
- org.eclipse.jst.server.ui;bundle-version="1.1.300"
+ org.eclipse.jst.server.ui;bundle-version="1.1.300",
+ org.jboss.tools.common.jdt.debug;bundle-version="3.10.2"
 Bundle-Activator: org.fusesource.ide.server.karaf.core.Activator
 Bundle-ActivationPolicy: lazy
 Export-Package: org.fusesource.ide.server.karaf.core,

--- a/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/server/subsystems/Karaf2xStartupLaunchConfigurator.java
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/server/subsystems/Karaf2xStartupLaunchConfigurator.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.server.karaf.core.server.subsystems;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.wst.server.core.IServer;
 import org.fusesource.ide.foundation.core.util.Strings;
+import org.fusesource.ide.server.karaf.core.runtime.IKarafRuntime;
 import org.fusesource.ide.server.karaf.core.util.IKarafToolingConstants;
 
 /**
@@ -30,8 +31,8 @@ public class Karaf2xStartupLaunchConfigurator extends BaseKarafStartupLaunchConf
 	}
 	
 	@Override
-	public String getVMArguments(String karafInstallDir, String endorsedDirs, String extDirs) {
-		StringBuilder vmArguments = new StringBuilder(super.getVMArguments(karafInstallDir, endorsedDirs, extDirs));
+	public String getVMArguments(String karafInstallDir, IKarafRuntime runtime, String endorsedDirs, String extDirs) {
+		StringBuilder vmArguments = new StringBuilder(super.getVMArguments(karafInstallDir, runtime, endorsedDirs, extDirs));
 		if (isNewerThanKaraf24()) {
 			vmArguments.append(SPACE + "-Dkaraf.etc=" + QUOTE + karafInstallDir + SEPARATOR + "etc" + QUOTE);
 			return vmArguments.toString();

--- a/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/server/subsystems/Karaf3xStartupLaunchConfigurator.java
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/server/subsystems/Karaf3xStartupLaunchConfigurator.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.server.karaf.core.server.subsystems;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.wst.server.core.IServer;
 import org.fusesource.ide.foundation.core.util.Strings;
+import org.fusesource.ide.server.karaf.core.runtime.IKarafRuntime;
 import org.fusesource.ide.server.karaf.core.util.IKarafToolingConstants;
 
 public class Karaf3xStartupLaunchConfigurator extends BaseKarafStartupLaunchConfigurator {
@@ -27,8 +28,8 @@ public class Karaf3xStartupLaunchConfigurator extends BaseKarafStartupLaunchConf
 	}
 	
 	@Override
-	public String getVMArguments(String karafInstallDir, String endorsedDirs, String extDirs) {
-		StringBuilder vmArguments = new StringBuilder(super.getVMArguments(karafInstallDir, endorsedDirs, extDirs));
+	public String getVMArguments(String karafInstallDir, IKarafRuntime runtime, String endorsedDirs, String extDirs) {
+		StringBuilder vmArguments = new StringBuilder(super.getVMArguments(karafInstallDir, runtime, endorsedDirs, extDirs));
 		vmArguments.append(SPACE + "-Dkaraf.etc=" + QUOTE + karafInstallDir + SEPARATOR + "etc" + QUOTE);
 		return vmArguments.toString();
 	}

--- a/servers/tests/org.fusesource.ide.server.fuse.core.tests/src/test/java/org/fusesource/ide/server/fuse/core/server/subsystems/Fuse6xStartupLaunchConfiguratorTest.java
+++ b/servers/tests/org.fusesource.ide.server.fuse.core.tests/src/test/java/org/fusesource/ide/server/fuse/core/server/subsystems/Fuse6xStartupLaunchConfiguratorTest.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.server.fuse.core.server.subsystems;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.wst.server.core.IServer;
+import org.fusesource.ide.server.karaf.core.runtime.KarafRuntimeDelegate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -26,10 +27,12 @@ public class Fuse6xStartupLaunchConfiguratorTest {
 	private IServer server;
 	@InjectMocks
 	private Fuse6xStartupLaunchConfigurator fuse6xStartupLaunchConfigurator;
+	@Mock
+	private KarafRuntimeDelegate runtime;
 
 	@Test
 	public void testGetVMArguments() throws Exception {
-		String vmArguments = fuse6xStartupLaunchConfigurator.getVMArguments("karafInstallDir", "endorsedDirs", "extDirs");
+		String vmArguments = fuse6xStartupLaunchConfigurator.getVMArguments("karafInstallDir", runtime, "endorsedDirs", "extDirs");
 		
 		assertThat(vmArguments)
 		.contains("PermSize")

--- a/servers/tests/org.fusesource.ide.server.fuse.core.tests/src/test/java/org/fusesource/ide/server/fuse/core/server/subsystems/Fuse7xStartupLaunchConfiguratorTest.java
+++ b/servers/tests/org.fusesource.ide.server.fuse.core.tests/src/test/java/org/fusesource/ide/server/fuse/core/server/subsystems/Fuse7xStartupLaunchConfiguratorTest.java
@@ -11,8 +11,11 @@
 package org.fusesource.ide.server.fuse.core.server.subsystems;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
+import org.eclipse.jdt.launching.AbstractVMInstall;
 import org.eclipse.wst.server.core.IServer;
+import org.fusesource.ide.server.fuse.core.runtime.FuseESBRuntimeDelegate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -25,15 +28,35 @@ public class Fuse7xStartupLaunchConfiguratorTest {
 	private IServer server;
 	@InjectMocks
 	private Fuse7xStartupLaunchConfigurator fuse7xStartupLaunchConfigurator;
+	@Mock
+	private FuseESBRuntimeDelegate runtime;
+	@Mock
+	AbstractVMInstall vmInstall;
 
 	@Test
 	public void testGetVMArguments() throws Exception {
-		String vmArguments = fuse7xStartupLaunchConfigurator.getVMArguments("karafInstallDir", "endorsedDirs", "extDirs");
+		String vmArguments = fuse7xStartupLaunchConfigurator.getVMArguments("karafInstallDir", runtime, "endorsedDirs", "extDirs");
 		
 		assertThat(vmArguments)
 		.doesNotContain("PermSize")
 		.contains("karaf.etc")
 		.doesNotContain("derby");
+	}
+	
+	@Test
+	public void testGetVMArgumentsForJava9AndMore() throws Exception {
+		when(runtime.getVM()).thenReturn(vmInstall);
+		when(vmInstall.getJavaVersion()).thenReturn("11.0.2");
+		
+		String vmArguments = fuse7xStartupLaunchConfigurator.getVMArguments("karafInstallDir", runtime, "endorsedDirs", "extDirs");
+		
+		assertThat(vmArguments)
+		.doesNotContain("PermSize")
+		.contains("karaf.etc")
+		.doesNotContain("derby")
+		.doesNotContain("endorsed")
+		.doesNotContain("ext.dir")
+		.doesNotContain("UnsyncloadClass");
 	}
 
 }

--- a/servers/tests/org.fusesource.ide.server.karaf.core.tests/src/test/java/org/fusesource/ide/server/karaf/core/server/subsystems/Karaf2xStartupLaunchConfiguratorTest.java
+++ b/servers/tests/org.fusesource.ide.server.karaf.core.tests/src/test/java/org/fusesource/ide/server/karaf/core/server/subsystems/Karaf2xStartupLaunchConfiguratorTest.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.server.karaf.core.server.subsystems;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.wst.server.core.IServer;
+import org.fusesource.ide.server.karaf.core.runtime.KarafRuntimeDelegate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -26,10 +27,12 @@ public class Karaf2xStartupLaunchConfiguratorTest {
 	private IServer server;
 	@InjectMocks
 	private Karaf2xStartupLaunchConfigurator karaf2xStartupLaunchConfigurator;
+	@Mock
+	private KarafRuntimeDelegate runtime;
 	
 	@Test
 	public void testGetVMArguments() throws Exception {
-		String vmArguments = karaf2xStartupLaunchConfigurator.getVMArguments("karafInstallDir", "endorsedDirs", "extDirs");
+		String vmArguments = karaf2xStartupLaunchConfigurator.getVMArguments("karafInstallDir", runtime, "endorsedDirs", "extDirs");
 		
 		assertThat(vmArguments)
 		.doesNotContain("PermSize")

--- a/servers/tests/org.fusesource.ide.server.karaf.core.tests/src/test/java/org/fusesource/ide/server/karaf/core/server/subsystems/Karaf3xStartupLaunchConfiguratorTest.java
+++ b/servers/tests/org.fusesource.ide.server.karaf.core.tests/src/test/java/org/fusesource/ide/server/karaf/core/server/subsystems/Karaf3xStartupLaunchConfiguratorTest.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.server.karaf.core.server.subsystems;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.wst.server.core.IServer;
+import org.fusesource.ide.server.karaf.core.runtime.KarafRuntimeDelegate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -25,10 +26,12 @@ public class Karaf3xStartupLaunchConfiguratorTest {
 	private IServer server;
 	@InjectMocks
 	private Karaf3xStartupLaunchConfigurator karaf3xStartupLaunchConfigurator;
+	@Mock
+	private KarafRuntimeDelegate runtime;
 
 	@Test
 	public void testGetVMArguments() throws Exception {
-		String vmArguments = karaf3xStartupLaunchConfigurator.getVMArguments("karafInstallDir", "endorsedDirs", "extDirs");
+		String vmArguments = karaf3xStartupLaunchConfigurator.getVMArguments("karafInstallDir", runtime, "endorsedDirs", "extDirs");
 		
 		assertThat(vmArguments)
 		.doesNotContain("PermSize")

--- a/servers/tests/org.fusesource.ide.server.karaf.core.tests/src/test/java/org/fusesource/ide/server/karaf/core/server/subsystems/Karaf4xStartupLaunchConfiguratorTest.java
+++ b/servers/tests/org.fusesource.ide.server.karaf.core.tests/src/test/java/org/fusesource/ide/server/karaf/core/server/subsystems/Karaf4xStartupLaunchConfiguratorTest.java
@@ -13,6 +13,7 @@ package org.fusesource.ide.server.karaf.core.server.subsystems;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.wst.server.core.IServer;
+import org.fusesource.ide.server.karaf.core.runtime.KarafRuntimeDelegate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -25,10 +26,12 @@ public class Karaf4xStartupLaunchConfiguratorTest {
 	private IServer server;
 	@InjectMocks
 	private Karaf4xStartupLaunchConfigurator karaf4xStartupLaunchConfigurator;
+	@Mock
+	private KarafRuntimeDelegate runtime;
 
 	@Test
 	public void testGetVMArguments() throws Exception {
-		String vmArguments = karaf4xStartupLaunchConfigurator.getVMArguments("karafInstallDir", "endorsedDirs", "extDirs");
+		String vmArguments = karaf4xStartupLaunchConfigurator.getVMArguments("karafInstallDir", runtime, "endorsedDirs", "extDirs");
 		
 		assertThat(vmArguments)
 		.doesNotContain("PermSize")


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

