### PR TITLE
FUSETOOLS-3186 - Use a cache for detecting if Camel project has Camel

### DIFF
--- a/editor/plugins/org.fusesource.ide.project/src/org/fusesource/ide/project/CamelNatureTester.java
+++ b/editor/plugins/org.fusesource.ide.project/src/org/fusesource/ide/project/CamelNatureTester.java
@@ -10,24 +10,28 @@
  ******************************************************************************/
 package org.fusesource.ide.project;
 
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.core.expressions.PropertyTester;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
-import org.fusesource.ide.foundation.ui.logging.RiderLogFacade;
 import org.eclipse.wst.common.project.facet.core.FacetedProjectFramework;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
+import org.fusesource.ide.foundation.ui.logging.RiderLogFacade;
 import org.fusesource.ide.project.providers.CamelVirtualFolder;
 
 /**
  * @author lhein
  */
 public class CamelNatureTester extends PropertyTester {
+	
+	private Map<IProject, CamelVirtualFolder> cache = new HashMap<>();
 
 	@Override
 	public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
@@ -49,8 +53,12 @@ public class CamelNatureTester extends PropertyTester {
 
 	private boolean hasChildren(IProject project) {
 		if (project.isOpen()) {
-			CamelVirtualFolder cvf = new CamelVirtualFolder(project);
-			cvf.populateChildren();
+			CamelVirtualFolder cvf = cache.get(project);
+			if (cvf == null) {
+				cvf = new CamelVirtualFolder(project);
+				cvf.populateChildren();
+				cache.put(project, cvf);
+			}
 			return !cvf.getCamelFiles().isEmpty();
 		}
 		return false;

--- a/editor/tests/org.fusesource.ide.project.tests.integration/META-INF/MANIFEST.MF
+++ b/editor/tests/org.fusesource.ide.project.tests.integration/META-INF/MANIFEST.MF
@@ -18,5 +18,6 @@ Require-Bundle: org.junit,
  org.fusesource.ide.launcher.ui,
  org.eclipse.debug.core,
  org.fusesource.ide.camel.model.service.core.tests.integration,
- org.fusesource.ide.camel.model.service.core
+ org.fusesource.ide.camel.model.service.core,
+ org.eclipse.core.expressions;bundle-version="3.6.300"
 Bundle-Vendor: %Bundle-Vendor

--- a/editor/tests/org.fusesource.ide.project.tests.integration/src/main/java/org/fusesource/ide/project/CamelNatureTesterIT.java
+++ b/editor/tests/org.fusesource.ide.project.tests.integration/src/main/java/org/fusesource/ide/project/CamelNatureTesterIT.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.fusesource.ide.project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.fusesource.ide.camel.model.service.core.model.CamelFile;
+import org.fusesource.ide.camel.model.service.core.tests.integration.core.io.FuseProject;
+import org.fusesource.ide.project.providers.CamelVirtualFolderIT;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CamelNatureTesterIT {
+	
+	@Rule
+	public FuseProject fuseProject = new FuseProject(CamelVirtualFolderIT.class.getName());
+	
+	@Test
+	public void testDetectRemovalOfFileForHasChildren() throws Exception {
+		CamelFile camelFile = fuseProject.createEmptyCamelFile();
+		CamelNatureTester camelNatureTester = new CamelNatureTester();
+		assertThat(camelNatureTester.test(fuseProject.getProject(), "hasChildren", null, null)).isTrue();
+		
+		camelFile.getResource().delete(true, new NullProgressMonitor());
+		
+		assertThat(camelNatureTester.test(fuseProject.getProject(), "hasChildren", null, null)).isFalse();
+	}
+
+}

--- a/editor/tests/org.fusesource.ide.project.tests.integration/src/main/java/org/fusesource/ide/project/CamelNatureTesterIT.java
+++ b/editor/tests/org.fusesource.ide.project.tests.integration/src/main/java/org/fusesource/ide/project/CamelNatureTesterIT.java
@@ -12,6 +12,10 @@ package org.fusesource.ide.project;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.InputStream;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
 import org.fusesource.ide.camel.model.service.core.tests.integration.core.io.FuseProject;
@@ -33,6 +37,17 @@ public class CamelNatureTesterIT {
 		camelFile.getResource().delete(true, new NullProgressMonitor());
 		
 		assertThat(camelNatureTester.test(fuseProject.getProject(), "hasChildren", null, null)).isFalse();
+	}
+	
+	@Test
+	public void testDetectCamelFilesWithMultpleContext() throws Exception {
+		IProject project = fuseProject.getProject();
+		IFile file = project.getFile("fileWithSeveralContext.xml");
+		try(InputStream source = CamelNatureTesterIT.class.getResourceAsStream("/fileWithSeveralContext.xml")){
+			file.create(source, true, new NullProgressMonitor());
+		}
+		CamelNatureTester camelNatureTester = new CamelNatureTester();
+		assertThat(camelNatureTester.test(fuseProject.getProject(), "hasChildren", null, null)).isTrue();
 	}
 
 }

--- a/editor/tests/org.fusesource.ide.project.tests.integration/src/main/resources/fileWithSeveralContext.xml
+++ b/editor/tests/org.fusesource.ide.project.tests.integration/src/main/resources/fileWithSeveralContext.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+    <camelContext id="emailingCamelContext"
+        xmlns="http://camel.apache.org/schema/spring">
+        <routeContextRef ref="emailingRoutes"/>
+    </camelContext>
+</beans>


### PR DESCRIPTION
xml files

The CamelVirtualFolder is already provisioning a listening mechanism

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

