### PR TITLE
FUSETOOLS-3186 - Avoid accessing classpath if nature already configured

### DIFF
--- a/syndesis/plugins/org.fusesource.ide.syndesis.extension.ui/src/org/fusesource/ide/syndesis/extensions/ui/maven/SyndesisExtensionProjectConfigurator.java
+++ b/syndesis/plugins/org.fusesource.ide.syndesis.extension.ui/src/org/fusesource/ide/syndesis/extensions/ui/maven/SyndesisExtensionProjectConfigurator.java
@@ -131,10 +131,11 @@ public class SyndesisExtensionProjectConfigurator extends AbstractProjectConfigu
 
 	@Override
 	public void configure(ProjectConfigurationRequest request, IProgressMonitor monitor) throws CoreException {
-		if (isValidSyndesisProject(request.getProject())) {
+		IProject project = request.getProject();
+		if (!project.hasNature(RiderProjectNature.NATURE_ID) && isValidSyndesisProject(project)) {
 			// we add the camel nature because this enables the Camel Contexts virtual folder in the project
 			SubMonitor subMonitor = SubMonitor.convert(monitor, 10);
-			addNature(request.getProject(), RiderProjectNature.NATURE_ID, subMonitor.split(10));
+			addNature(project, RiderProjectNature.NATURE_ID, subMonitor.split(10));
 		}
 	}
 }


### PR DESCRIPTION
it can cause important delay if the Maven project has not been
initialized yet.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

