### PR TITLE
FUSETOOLS-3243 - respect usage of productized group id or not

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/CamelCatalogUtils.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/CamelCatalogUtils.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
@@ -74,6 +75,9 @@ public class CamelCatalogUtils {
 	
 	public static final String CATALOG_WILDFLY_GROUPID = CAMEL_WILDFLY;
 	public static final String CATALOG_WILDFLY_ARTIFACTID = "wildfly-camel-catalog";
+	
+	private static final String MAVEN_PLUGIN_GROUPID_FUSE_PRODUCTIZED = "org.jboss.redhat-fuse";
+	private static final List<String> MAVEN_PLUGINS_WITH_FUSEPRODUCTIZED_GROUPID = Arrays.asList("camel-maven-plugin", "spring-boot-maven-plugin");
 	
 	public static final String GAV_KEY_GROUPID = "groupId";
 	public static final String GAV_KEY_ARTIFACTID = "artifactId";
@@ -427,5 +431,15 @@ public class CamelCatalogUtils {
 			artifactToSearch.setArtifactId("fabric8-maven-plugin");
 			return new OnlineArtifactVersionSearcher().findLatestVersion(monitor, artifactToSearch);
 		}
+	}
+
+	public static boolean hasProductizedMavenPluginGroupId(List<Plugin> plugins) {
+		return hasPluginWithFuseProductizedGroupID(plugins, MAVEN_PLUGINS_WITH_FUSEPRODUCTIZED_GROUPID);
+	}
+	
+	private static boolean hasPluginWithFuseProductizedGroupID(List<org.apache.maven.model.Plugin> plugins, List<String> pluginsToCheck) {
+		return plugins != null
+				&& plugins.stream()
+					.anyMatch(plugin -> pluginsToCheck.contains(plugin.getArtifactId()) && MAVEN_PLUGIN_GROUPID_FUSE_PRODUCTIZED.equals(plugin.getGroupId()));
 	}
 }

--- a/editor/plugins/org.fusesource.ide.launcher.ui/src/org/fusesource/ide/launcher/ui/tabs/CamelContextFileTab.java
+++ b/editor/plugins/org.fusesource.ide.launcher.ui/src/org/fusesource/ide/launcher/ui/tabs/CamelContextFileTab.java
@@ -127,7 +127,7 @@ public class CamelContextFileTab extends AbstractLaunchConfigurationTab {
 	@Override
 	public void setDefaults(ILaunchConfigurationWorkingCopy configuration) {
 		configuration.setAttribute(CamelContextLaunchConfigConstants.ATTR_FILE, CamelContextLaunchConfigConstants.DEFAULT_CONTEXT_NAME);
-		configuration.setAttribute(MavenLaunchConstants.ATTR_GOALS, "clean package org.apache.camel:camel-maven-plugin:run");
+		configuration.setAttribute(MavenLaunchConstants.ATTR_GOALS, CamelContextLaunchConfigConstants.DEFAULT_MAVEN_GOALS_JAR_FUSE_PRODUCTIZED);
 	}
 
 	/* (non-Javadoc)

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/run/launching/CamelRunMavenLaunchDelegate.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/run/launching/CamelRunMavenLaunchDelegate.java
@@ -61,13 +61,26 @@ public class CamelRunMavenLaunchDelegate extends FuseMavenLaunchDelegate {
 		}
 		
 		if (isSpringBoot(pomFile)) {
-			setGoals(CamelContextLaunchConfigConstants.DEFAULT_MAVEN_GOALS_SPRINGBOOT);
+			if (isProductizedMavenPluginUsed(pomFile)) {
+				setGoals(CamelContextLaunchConfigConstants.DEFAULT_MAVEN_GOALS_SPRINGBOOT_FUSE_PRODUCTIZED);
+			} else {
+				setGoals(CamelContextLaunchConfigConstants.DEFAULT_MAVEN_GOALS_SPRINGBOOT);
+			}
 		} else if (isWarPackaging(pomFile)) {
 			setGoals(CamelContextLaunchConfigConstants.DEFAULT_MAVEN_GOALS_WAR);
 		} else {
-			setGoals(CamelContextLaunchConfigConstants.DEFAULT_MAVEN_GOALS_JAR);
+			if (isProductizedMavenPluginUsed(pomFile)) {
+				setGoals(CamelContextLaunchConfigConstants.DEFAULT_MAVEN_GOALS_JAR_FUSE_PRODUCTIZED);
+			} else {
+				setGoals(CamelContextLaunchConfigConstants.DEFAULT_MAVEN_GOALS_JAR);
+			}
+
 		}
 		return "-U " + super.getGoals(configuration) + newGoalsAdditionForFile;
+	}
+
+	protected boolean isProductizedMavenPluginUsed(IFile pomFile) throws CoreException {
+		return MavenLaunchUtils.isProductizedMavenPluginGroupIdUsed(pomFile);
 	}
 
 	/**

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/run/util/CamelContextLaunchConfigConstants.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/run/util/CamelContextLaunchConfigConstants.java
@@ -23,10 +23,14 @@ public interface CamelContextLaunchConfigConstants {
 	static final String DEFAULT_CONTEXT_NAME = "camelContext.xml";
 	static final String DEFAULT_MAVEN_GOALS_ALL = "clean package";
 	static final String SPECIFIC_MAVEN_GOAL_JAR = "org.apache.camel:camel-maven-plugin:run";
+	static final String SPECIFIC_MAVEN_GOAL_JAR_FUSE_PRODUCTIZED = "org.jboss.redhat-fuse:camel-maven-plugin:run";
 	static final String SPECIFIC_MAVEN_GOAL_WAR = "org.eclipse.jetty:jetty-maven-plugin:run";
 	static final String SPECIFIC_MAVEN_GOAL_SPRINGBOOT = "org.springframework.boot:spring-boot-maven-plugin:run";
+	static final String SPECIFIC_MAVEN_GOAL_SPRINGBOOT_FUSE_PRODUCTIZED = "org.jboss.redhat-fuse:spring-boot-maven-plugin:run";
 	static final String DEFAULT_MAVEN_GOALS_JAR = DEFAULT_MAVEN_GOALS_ALL + " "+SPECIFIC_MAVEN_GOAL_JAR;
-	static final String DEFAULT_MAVEN_GOALS_WAR = DEFAULT_MAVEN_GOALS_ALL + " "+SPECIFIC_MAVEN_GOAL_WAR;
-	static final String DEFAULT_MAVEN_GOALS_SPRINGBOOT = DEFAULT_MAVEN_GOALS_ALL + " "+SPECIFIC_MAVEN_GOAL_SPRINGBOOT;
+	static final String DEFAULT_MAVEN_GOALS_JAR_FUSE_PRODUCTIZED = DEFAULT_MAVEN_GOALS_ALL + " " + SPECIFIC_MAVEN_GOAL_JAR_FUSE_PRODUCTIZED;
+	static final String DEFAULT_MAVEN_GOALS_WAR = DEFAULT_MAVEN_GOALS_ALL + " " + SPECIFIC_MAVEN_GOAL_WAR;
+	static final String DEFAULT_MAVEN_GOALS_SPRINGBOOT = DEFAULT_MAVEN_GOALS_ALL + " " + SPECIFIC_MAVEN_GOAL_SPRINGBOOT;
+	static final String DEFAULT_MAVEN_GOALS_SPRINGBOOT_FUSE_PRODUCTIZED = DEFAULT_MAVEN_GOALS_ALL + " " + SPECIFIC_MAVEN_GOAL_SPRINGBOOT_FUSE_PRODUCTIZED;
 	static final String BLUEPRINT_CONTEXT = "camel.blueprint=true";
 }

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/run/util/MavenLaunchUtils.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/run/util/MavenLaunchUtils.java
@@ -19,6 +19,7 @@
 
 package org.fusesource.ide.launcher.run.util;
 
+import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -72,14 +73,31 @@ public class MavenLaunchUtils {
 	 * @throws CoreException
 	 */
 	public static boolean isPackagingTypeWAR(IFile pomFile) throws CoreException {
-		if (pomFile == null || !pomFile.exists()) throw new CoreException(new Status(IStatus.ERROR, Activator.getBundleID(), "Can't determine packaging type because given pom file reference is null!"));
+		if (pomFile == null || !pomFile.exists()) {
+			throw new CoreException(new Status(IStatus.ERROR, Activator.getBundleID(), "Can't determine packaging type because given pom file reference is null!"));
+		}
 		Model model = MavenPlugin.getMavenModelManager().readMavenModel(pomFile);
 		return "war".equalsIgnoreCase(model.getPackaging());
 	}
 	
 	public static boolean isSpringBootProject(IFile pomFile) throws CoreException {
-		if (pomFile == null || !pomFile.exists()) throw new CoreException(new Status(IStatus.ERROR, Activator.getBundleID(), "Can't determine project type because given pom file reference is null!"));
+		if (pomFile == null || !pomFile.exists()) {
+			throw new CoreException(new Status(IStatus.ERROR, Activator.getBundleID(), "Can't determine project type because given pom file reference is null!"));
+		}
 		Model model = MavenPlugin.getMavenModelManager().readMavenModel(pomFile);
 		return CamelCatalogUtils.hasSpringBootDependency(model.getDependencies());
+	}
+
+	public static boolean isProductizedMavenPluginGroupIdUsed(IFile pomFile) throws CoreException {
+		if (pomFile == null || !pomFile.exists()) {
+			throw new CoreException(new Status(IStatus.ERROR, Activator.getBundleID(), "Can't determine if productized group id used because given pom file reference is null!"));
+		}
+		Model model = MavenPlugin.getMavenModelManager().readMavenModel(pomFile);
+		Build build = model.getBuild();
+		if (build != null) {
+			return CamelCatalogUtils.hasProductizedMavenPluginGroupId(build.getPlugins());
+		} else {
+			throw new CoreException(new Status(IStatus.ERROR, Activator.getBundleID(), "Can't determine if productized group id used because given pom file doesn't contain a build section!"));
+		}
 	}
 }

--- a/editor/tests/org.fusesource.ide.launcher.tests/src/test/java/org/fusesource/ide/launcher/run/launching/CamelRunMavenLaunchDelegateTest.java
+++ b/editor/tests/org.fusesource.ide.launcher.tests/src/test/java/org/fusesource/ide/launcher/run/launching/CamelRunMavenLaunchDelegateTest.java
@@ -11,6 +11,8 @@
 package org.fusesource.ide.launcher.run.launching;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
@@ -21,7 +23,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -35,24 +36,44 @@ public class CamelRunMavenLaunchDelegateTest {
 	@Before
 	public void setup() throws Exception {
 		doReturn("file:C:\\my%20path%20with%20space").when(launchConfig).getAttribute(CamelContextLaunchConfigConstants.ATTR_FILE, (String) null);
-		doReturn(null).when(camelRunMavenLaunchDelegate).getFileInWorkspace(Mockito.anyString());
-		doReturn(false).when(camelRunMavenLaunchDelegate).isWarPackaging(Mockito.any(IFile.class));
+		doReturn(null).when(camelRunMavenLaunchDelegate).getFileInWorkspace(anyString());
+		doReturn(false).when(camelRunMavenLaunchDelegate).isWarPackaging(any(IFile.class));
 	}
 
 	@Test
-	public void testGetGoals() throws Exception {
-		doReturn(false).when(camelRunMavenLaunchDelegate).isSpringBoot(Mockito.any(IFile.class));
+	public void testGetGoalsForNonSpringBootNonProductizedGroupId() throws Exception {
+		doReturn(false).when(camelRunMavenLaunchDelegate).isSpringBoot(any(IFile.class));
+		doReturn(false).when(camelRunMavenLaunchDelegate).isProductizedMavenPluginUsed(any(IFile.class));
 		
 		assertThat(camelRunMavenLaunchDelegate.getGoals(launchConfig))
 				.isEqualTo("-U clean package org.apache.camel:camel-maven-plugin:run -Dcamel.fileApplicationContextUri=\"file:C:\\my path with space\"");
 	}
 	
 	@Test
-	public void testGetGoalsForSpringBoot() throws Exception {
-		doReturn(true).when(camelRunMavenLaunchDelegate).isSpringBoot(Mockito.any(IFile.class));
+	public void testGetGoalsForNonSpringBootAndProductizedGroupId() throws Exception {
+		doReturn(false).when(camelRunMavenLaunchDelegate).isSpringBoot(any(IFile.class));
+		doReturn(true).when(camelRunMavenLaunchDelegate).isProductizedMavenPluginUsed(any(IFile.class));
+		
+		assertThat(camelRunMavenLaunchDelegate.getGoals(launchConfig))
+				.isEqualTo("-U clean package org.jboss.redhat-fuse:camel-maven-plugin:run -Dcamel.fileApplicationContextUri=\"file:C:\\my path with space\"");
+	}
+	
+	@Test
+	public void testGetGoalsForSpringBootNonProductizedGroupId() throws Exception {
+		doReturn(true).when(camelRunMavenLaunchDelegate).isSpringBoot(any(IFile.class));
+		doReturn(false).when(camelRunMavenLaunchDelegate).isProductizedMavenPluginUsed(any(IFile.class));
 		
 		assertThat(camelRunMavenLaunchDelegate.getGoals(launchConfig))
 				.isEqualTo("-U clean package org.springframework.boot:spring-boot-maven-plugin:run -Dcamel.fileApplicationContextUri=\"file:C:\\my path with space\"");
+	}
+	
+	@Test
+	public void testGetGoalsForSpringBootAndProductizedGroupId() throws Exception {
+		doReturn(true).when(camelRunMavenLaunchDelegate).isSpringBoot(any(IFile.class));
+		doReturn(true).when(camelRunMavenLaunchDelegate).isProductizedMavenPluginUsed(any(IFile.class));
+		
+		assertThat(camelRunMavenLaunchDelegate.getGoals(launchConfig))
+				.isEqualTo("-U clean package org.jboss.redhat-fuse:spring-boot-maven-plugin:run -Dcamel.fileApplicationContextUri=\"file:C:\\my path with space\"");
 	}
 
 }


### PR DESCRIPTION
this is providing a fix with minimal change.
The current behavior is quite strange as it is overriding what the user
has provided in the Main tab of the launch configuration every time. it
would be better to provide warning in case the value is suspected to be
not correct instead of silently overriding it

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

