### PR TITLE
FUSETOOLS-3244 - use less dummy pom files for tests

### DIFF
--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/META-INF/MANIFEST.MF
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/META-INF/MANIFEST.MF
@@ -14,14 +14,14 @@ Require-Bundle: org.eclipse.core.filesystem,
  org.assertj.core;bundle-version="2.1.0",
  org.junit;bundle-version="4.12.0",
  org.jboss.tools.locus.mockito;bundle-version="1.9.5",
+ org.eclipse.m2e.maven.runtime;bundle-version="1.6.2",
+ org.eclipse.m2e.core;bundle-version="1.7.1",
  org.fusesource.ide.foundation.core;bundle-version="10.0.0",
  org.fusesource.ide.foundation.ui;bundle-version="10.0.0",
  org.fusesource.ide.camel.model.service.core;bundle-version="10.0.0",
  org.fusesource.ide.camel.model.service.impl;bundle-version="10.0.0",
  org.fusesource.ide.camel.editor;bundle-version="10.0.0",
- org.fusesource.ide.preferences;bundle-version="10.0.0",
- org.eclipse.m2e.maven.runtime;bundle-version="1.6.2",
- org.eclipse.m2e.core;bundle-version="1.7.1"
+ org.fusesource.ide.preferences;bundle-version="10.0.0"
 Export-Package: org.fusesource.ide.camel.model.service.core.tests.integration.core.io
 Bundle-Activator: org.fusesource.ide.camel.model.service.core.tests.integration.core.CamelModelServiceIntegrationTestActivator
 Bundle-Vendor: Red Hat

--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/java/org/fusesource/ide/camel/model/service/core/tests/integration/core/io/FuseProject.java
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/java/org/fusesource/ide/camel/model/service/core/tests/integration/core/io/FuseProject.java
@@ -28,7 +28,11 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.project.IProjectConfigurationManager;
+import org.eclipse.m2e.core.project.ResolverConfiguration;
+import org.fusesource.ide.camel.editor.utils.BuildAndRefreshJobWaiterUtil;
 import org.fusesource.ide.camel.model.service.core.io.CamelIOHandler;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
 import org.fusesource.ide.camel.model.service.core.tests.integration.core.CamelModelServiceIntegrationTestActivator;
@@ -91,6 +95,19 @@ public class FuseProject extends ExternalResource {
 		IFolder srcMainFolder = srcFolder.getFolder("main");
 		srcMainFolder.create(IResource.FORCE, true, new NullProgressMonitor());
 		srcMainFolder.getFolder("java").create(IResource.FORCE, true, new NullProgressMonitor());
+		
+		enableMavenNature();
+	}
+
+	private void enableMavenNature() throws CoreException {
+		ResolverConfiguration configuration = new ResolverConfiguration();
+		configuration.setResolveWorkspaceProjects(true);
+		configuration.setSelectedProfiles(""); //$NON-NLS-1$
+		new BuildAndRefreshJobWaiterUtil().waitJob(new NullProgressMonitor());
+		IProjectConfigurationManager configurationManager = MavenPlugin.getProjectConfigurationManager();
+		configurationManager.enableMavenNature(project, configuration, new NullProgressMonitor());
+		configurationManager.updateProjectConfiguration(project, new NullProgressMonitor());
+		new BuildAndRefreshJobWaiterUtil().waitJob(new NullProgressMonitor());
 	}
 
 	private static String getDummyPomContent(String type) {

--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/resources/dummyBlueprintPom.xml
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/resources/dummyBlueprintPom.xml
@@ -28,6 +28,12 @@
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
+      <plugin>
+		<groupId>org.apache.felix</groupId>
+		<artifactId>maven-bundle-plugin</artifactId>
+		<version>4.2.0</version>
+		<extensions>true</extensions>
+	  </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/resources/dummySpringPom.xml
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/resources/dummySpringPom.xml
@@ -25,6 +25,12 @@
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
+      <plugin>
+		<groupId>org.apache.felix</groupId>
+		<artifactId>maven-bundle-plugin</artifactId>
+		<version>4.2.0</version>
+		<extensions>true</extensions>
+	  </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/core/tests/org.fusesource.ide.camel.tests.util/src/org/fusesource/ide/camel/test/util/editor/AbstractCamelEditorIT.java
+++ b/core/tests/org.fusesource.ide.camel.tests.util/src/org/fusesource/ide/camel/test/util/editor/AbstractCamelEditorIT.java
@@ -33,9 +33,13 @@ import org.eclipse.ui.ide.IDE;
 import org.fusesource.ide.branding.perspective.FusePerspective;
 import org.fusesource.ide.camel.editor.utils.CamelUtils;
 import org.fusesource.ide.camel.model.service.core.tests.integration.core.io.FuseProject;
+import org.fusesource.ide.camel.tests.util.Activator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 
 public class AbstractCamelEditorIT {
 	
@@ -48,6 +52,14 @@ public class AbstractCamelEditorIT {
 	StatusHandler statusHandlerBeforetest;
 	
 	protected String routeContainerType;
+
+	@Rule
+	public TestRule watcher = new TestWatcher() {
+		@Override
+		protected void starting(Description description) {
+			Activator.pluginLog().logInfo("Starting test: " + description.getDisplayName());
+		}
+	};
 
 	public AbstractCamelEditorIT() {
 		super();

--- a/editor/tests/org.fusesource.ide.camel.editor.tests.integration/src/main/java/org/fusesource/ide/camel/editor/integration/CamelEditorMoveIT.java
+++ b/editor/tests/org.fusesource.ide.camel.editor.tests.integration/src/main/java/org/fusesource/ide/camel/editor/integration/CamelEditorMoveIT.java
@@ -29,7 +29,6 @@ import org.fusesource.ide.camel.test.util.editor.AbstractCamelEditorIT;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
@@ -45,7 +44,7 @@ public class CamelEditorMoveIT extends AbstractCamelEditorIT {
 	public CamelEditorMoveIT(String routeContainerType) {
 		this.routeContainerType = routeContainerType;
 	}
-
+	
 	@Test
 	public void testMoveInsideSameContainerNotAllowed() throws Exception {
 		IEditorPart openEditorOnFileStore = openFileInEditor("/moveInRoute");


### PR DESCRIPTION
new version of m2e is less permissive and doesn't accept anymore a
packaging type which is not provided by one of the Maven plugin
dependency inside the pom.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

