### PR TITLE
FUSETOOLS-3254 - avoid setting back the cursor to beginning when typing

### DIFF
--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/restconfiguration/RestConfigEditor.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/restconfiguration/RestConfigEditor.java
@@ -600,9 +600,13 @@ public class RestConfigEditor extends EditorPart implements ICamelModelListener,
 			value = OFF; // set default 
 		}
 		if (control instanceof Text) {
-			((Text)control).setText(value);
+			if (!value.equals(((Text)control).getText())) {
+				((Text)control).setText(value);
+			}
 		} else if (control instanceof Combo) {
-			((Combo)control).setText(value);
+			if (!value.equals(((Combo)control).getText())) {
+				((Combo)control).setText(value);
+			}
 		}
 	}
 	


### PR DESCRIPTION
the trick is to avoid to reset value from model to SWT Widget when it is
already the same. this problem is coming by the usage of Listeners
instead of Databinding. It would be better to use Databinding but
requires an important rewrite that we don't have time to do given
current priorities.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

