### PR TITLE
FUSETOOLS-3248 - reactivate a subpart of NewDataFormatWizardIT tests

### DIFF
--- a/editor/tests/org.fusesource.ide.camel.editor.tests.integration/src/main/java/org/fusesource/ide/camel/editor/integration/globalconfiguration/dataformat/wizards/NewDataFormatWizardIT.java
+++ b/editor/tests/org.fusesource.ide.camel.editor.tests.integration/src/main/java/org/fusesource/ide/camel/editor/integration/globalconfiguration/dataformat/wizards/NewDataFormatWizardIT.java
@@ -44,7 +44,6 @@ import org.fusesource.ide.camel.model.service.core.util.CamelMavenUtils;
 import org.fusesource.ide.camel.tests.util.Activator;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -91,7 +90,11 @@ public class NewDataFormatWizardIT {
 		for (String camelVersion : supportedCamelVersions) {
 			CamelModel camelModel = CamelCatalogCacheManager.getInstance().getDefaultCamelModel(camelVersion);
 			Collection<DataFormat> supportedDataFormats = camelModel.getDataFormats();
-			Stream<Object[]> stream = supportedDataFormats.stream().map(dataFormat -> new Object[] { camelVersion, dataFormat.getName(), dataFormat });
+			Stream<Object[]> stream = supportedDataFormats.stream()
+					.filter(dataFormat -> 
+					dataFormat.getName().contains("bindy") || dataFormat.getName().contains("json") // the special ones
+					|| dataFormat.getName().contains("avro"))// a classic one
+					.map(dataFormat -> new Object[] { camelVersion, dataFormat.getName(), dataFormat });
 			res.addAll(stream.collect(Collectors.toCollection(HashSet::new)));
 		}
 		return res;
@@ -109,7 +112,6 @@ public class NewDataFormatWizardIT {
 	}
 
 	@Test
-	@Ignore("Timeout on CI surely due to the fact that tests are now taking more time as Maven configuration needs to be done. Ignoring for now to try to unblock situation for Code freeze. Tests are passing fine (but slowly) locally.")
 	public void testCreationWithDeps() throws CoreException, IOException, InterruptedException, InvocationTargetException {
 		final String id = dataFormat.getName() + "-id2";
 		Activator.pluginLog().logInfo("NewDataFormatWizardIT.testCreationWithDeps for: " + dataFormat.getName());


### PR DESCRIPTION
not found a way to have tests playing faster in a reliable way fo rnow
so reactivating only a subpart which is covering some specific cases and
the generic one. it won't detect if a dataformat from the catalog is
added with wrong values but this part should be handled by Camel itself
anyway. Also don't detect in case of specific case, this part stays a
problem onb our side.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

