### PR TITLE
FUSETOOLS2-49 - Add sonar.organization to default

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,7 @@
 sonar.projectKey=fusetools
 # this is the name and version displayed in the SonarQube UI. Was mandatory prior to SonarQube 6.1.
 sonar.projectName=Red Hat Fuse Tooling
+sonar.organization=default
  
 # Path is relative to the sonar-project.properties file. Replace "\\" by "/" on Windows.
 # Since SonarQube 4.2, this property is optional if sonar.modules is set. 


### PR DESCRIPTION
Since we are one of the early adopters of SonarCloud, our project still
belongs to the "Attic" organization - which was originally the only
organization on SonarCloud when the service started. Because of this,
until now, we did not have to specify the "sonar.organization" property
on our project since it was defaulting to the "Attic" org. For
consistency reasons, SonarSource are going to make this property
mandatory, which means that we have to set it to "default".

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

