### PR TITLE
FUSETOOLS-3333 - avoid NPE with UpdatevalueStrategy

### DIFF
--- a/syndesis/plugins/org.fusesource.ide.syndesis.extension.ui/src/org/fusesource/ide/syndesis/extensions/ui/wizards/pages/SyndesisExtensionProjectWizardExtensionDetailsPage.java
+++ b/syndesis/plugins/org.fusesource.ide.syndesis.extension.ui/src/org/fusesource/ide/syndesis/extensions/ui/wizards/pages/SyndesisExtensionProjectWizardExtensionDetailsPage.java
@@ -160,14 +160,14 @@ public class SyndesisExtensionProjectWizardExtensionDetailsPage extends WizardPa
 		extensionDetailsLabel.setLayoutData(gridData);
 		
 		Text extensionIdText = createField(container, Messages.newProjectWizardExtensionDetailsPageExtensionIdLabel, null, Messages.newProjectWizardExtensionDetailsPageExtensionIdTooltip);
-		UpdateValueStrategy updateStrategy = UpdateValueStrategy.create(null);
+		UpdateValueStrategy<String, String> updateStrategy = new UpdateValueStrategy<>();
 		updateStrategy.setBeforeSetValidator(new SyndesisExtensionIdValidator());		
 		createBinding(dbc, extensionIdText, "extensionId", updateStrategy);
 		// set a default value
 		extensionIdText.setText(DEFAULT_EXTENSION_ID);
 		
 		Text extensionNameText = createField(container, Messages.newProjectWizardExtensionDetailsPageNameLabel, null, Messages.newProjectWizardExtensionDetailsPageNameTooltip);
-		updateStrategy = UpdateValueStrategy.create(null);
+		updateStrategy = new UpdateValueStrategy<>();
 		updateStrategy.setBeforeSetValidator(new SyndesisExtensionNameValidator());
 		createBinding(dbc, extensionNameText, "name", updateStrategy);
 		// set a default value
@@ -177,7 +177,7 @@ public class SyndesisExtensionProjectWizardExtensionDetailsPage extends WizardPa
 		createBinding(dbc, extensionDescriptionText, "description");
 
 		Text extensionVersionText = createField(container, Messages.newProjectWizardExtensionDetailsPageVersionLabel, null, Messages.newProjectWizardExtensionDetailsPageVersionTooltip);
-		updateStrategy = UpdateValueStrategy.create(null);
+		updateStrategy = new UpdateValueStrategy<>();
 		updateStrategy.setBeforeSetValidator(new SyndesisExtensionVersionValidator());
 		createBinding(dbc, extensionVersionText, "version", updateStrategy);
 		// set a default value
@@ -242,8 +242,7 @@ public class SyndesisExtensionProjectWizardExtensionDetailsPage extends WizardPa
 		syndesisVersionCombo.setLabelProvider(new SyndesisVersionLabelProvider());
 		syndesisVersionCombo.setComparator(new ViewerComparator(Comparator.reverseOrder()));
 		syndesisVersionCombo.setContentProvider(ArrayContentProvider.getInstance());
-		UpdateValueStrategy updateStrategy = UpdateValueStrategy.create(null);
-		updateStrategy.setConverter(IConverter.create(String.class, String.class, o1 -> translateDisplayTextToVersion((String) o1)));
+		UpdateValueStrategy<String, String> updateStrategy = UpdateValueStrategy.create(IConverter.create(String.class, String.class, o1 -> translateDisplayTextToVersion(o1)));
 		updateStrategy.setBeforeSetValidator(new SyndesisExtensionVersionValidator());
 		createBinding(dbc, syndesisVersionCombo.getCombo(), "syndesisVersion", updateStrategy);
 		

--- a/syndesis/plugins/org.fusesource.ide.syndesis.extension.ui/src/org/fusesource/ide/syndesis/extensions/ui/wizards/validation/SyndesisExtensionIdValidator.java
+++ b/syndesis/plugins/org.fusesource.ide.syndesis.extension.ui/src/org/fusesource/ide/syndesis/extensions/ui/wizards/validation/SyndesisExtensionIdValidator.java
@@ -19,11 +19,10 @@ import org.fusesource.ide.syndesis.extensions.ui.internal.Messages;
 /**
  * @author lheinema
  */
-public class SyndesisExtensionIdValidator implements IValidator {
+public class SyndesisExtensionIdValidator implements IValidator<String> {
 
 	@Override
-	public IStatus validate(Object value) {
-		String id = (String) value;
+	public IStatus validate(String id) {
 		if (Strings.isBlank(id)) {
 			return ValidationStatus.error(Messages.newProjectWizardExtensionDetailsPageErrorMissingExtensionId);
 		} else if (id.indexOf(' ') != -1) {

--- a/syndesis/plugins/org.fusesource.ide.syndesis.extension.ui/src/org/fusesource/ide/syndesis/extensions/ui/wizards/validation/SyndesisExtensionNameValidator.java
+++ b/syndesis/plugins/org.fusesource.ide.syndesis.extension.ui/src/org/fusesource/ide/syndesis/extensions/ui/wizards/validation/SyndesisExtensionNameValidator.java
@@ -19,11 +19,10 @@ import org.fusesource.ide.syndesis.extensions.ui.internal.Messages;
 /**
  * @author lheinema
  */
-public class SyndesisExtensionNameValidator implements IValidator {
+public class SyndesisExtensionNameValidator implements IValidator<String> {
 
 	@Override
-	public IStatus validate(Object value) {
-		String name = (String) value;
+	public IStatus validate(String name) {
 		if (Strings.isBlank(name)) {
 			return ValidationStatus.error(Messages.newProjectWizardExtensionDetailsPageErrorMissingExtensionName);
 		} 

--- a/syndesis/plugins/org.fusesource.ide.syndesis.extension.ui/src/org/fusesource/ide/syndesis/extensions/ui/wizards/validation/SyndesisExtensionVersionValidator.java
+++ b/syndesis/plugins/org.fusesource.ide.syndesis.extension.ui/src/org/fusesource/ide/syndesis/extensions/ui/wizards/validation/SyndesisExtensionVersionValidator.java
@@ -20,11 +20,10 @@ import org.fusesource.ide.syndesis.extensions.ui.internal.Messages;
 /**
  * @author lheinema
  */
-public class SyndesisExtensionVersionValidator implements IValidator {
+public class SyndesisExtensionVersionValidator implements IValidator<String> {
 
 	@Override
-	public IStatus validate(Object value) {
-		String version = (String) value;
+	public IStatus validate(String version) {
 		if (Strings.isBlank(version)) {
 			return ValidationStatus.error(Messages.newProjectWizardExtensionDetailsPageErrorMissingExtensionVersion);
 		} else if (!SyndesisExtensionsUtil.isValidSyndesisExtensionVersion(version)) {


### PR DESCRIPTION
new version of Target Platform doesn't allow anymore to use
UpdateValueStrategy.create(Converter) with a null value.

also specify generic types for better readability

blind push awaiting local target Platform build but at least it will start build of PRs in case it is enough