### PR TITLE
Fusetools 3327 revert

### DIFF
--- a/editor/plugins/org.fusesource.ide.wsdl2rest.ui/.classpath
+++ b/editor/plugins/org.fusesource.ide.wsdl2rest.ui/.classpath
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry exported="true" kind="lib" path="libs/commons-lang3.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
@@ -20,8 +21,6 @@
 	<classpathentry exported="true" kind="lib" path="libs/commons-digester.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/commons-logging.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/commons-validator.jar"/>
-	<classpathentry exported="true" kind="lib" path="libs/commons-lang.jar"/>
-	<classpathentry exported="true" kind="lib" path="libs/commons-lang3.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/cxf-codegen-plugin.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/cxf-core.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/cxf-rt-bindings-soap.jar"/>

--- a/editor/plugins/org.fusesource.ide.wsdl2rest.ui/pom.xml
+++ b/editor/plugins/org.fusesource.ide.wsdl2rest.ui/pom.xml
@@ -13,8 +13,8 @@
 	<name>Red Hat Fuse Tooling :: Camel Editor :: Plugins :: Wsdl2Rest UI</name>
 
 <properties>
-		<version.apache.camel>2.21.0.fuse-760027-redhat-00001</version.apache.camel>
-		<version.apache.cxf>3.2.7.fuse-760026-redhat-00001</version.apache.cxf>
+		<version.apache.camel>2.21.0.fuse-730078-redhat-00001</version.apache.camel>
+		<version.apache.cxf>3.2.7.fuse-730040-redhat-00001</version.apache.cxf>
 		<version.apache.velocity>1.7.0.redhat-5</version.apache.velocity>
 		<version.args4j>2.33</version.args4j>
 		<version.javaparser>2.5.1</version.javaparser>
@@ -24,7 +24,9 @@
 		<version.jaxb-api>2.3.0</version.jaxb-api>
 		<version.wsdl4j>1.6.3.redhat-2</version.wsdl4j>
 		<version.commons.validator>1.6</version.commons.validator>
-		<version.wsdl2rest>0.8.0.fuse-760026-redhat-00001</version.wsdl2rest>
+		<!-- TODO: Adjust this wsdl2rest version to the final Fuse productized 
+			version when it is available -->
+		<version.wsdl2rest>0.8.0.fuse-730094-redhat-00001</version.wsdl2rest>
 		<version.commons.collections>3.2.2</version.commons.collections>
 		<version.commons.lang>2.4</version.commons.lang>
         <version.commons.lang3>3.5</version.commons.lang3>

--- a/editor/plugins/org.fusesource.ide.wsdl2rest.ui/pom.xml
+++ b/editor/plugins/org.fusesource.ide.wsdl2rest.ui/pom.xml
@@ -214,16 +214,5 @@
 		</plugins>
 	</build>
 
-	<repositories>
-		<repository>
-			<id>jboss.central</id>
-			<url>https://repository.jboss.org/nexus/content/repositories/central/</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
+
 </project>


### PR DESCRIPTION
several builds locally and on CI on success... but it has just failed on master branch https://fusesource-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/jbosstools-fuse_master/1072/console

given the amount of time we have before the code freeze (which is today)
I think I will revert and we will ship without latest wsdl2rest
it was blocked on 7.3 version before anyway and nobody complained