### PR TITLE
FUSETOOLS-3340 - fix activeMQ dependency for SpringBoot

### DIFF
--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/ActiveMQPaletteEntry.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/ActiveMQPaletteEntry.java
@@ -51,7 +51,7 @@ public class ActiveMQPaletteEntry implements ICustomPaletteEntry {
 	@Override
 	public List<Dependency> getRequiredDependencies(String runtimeProvider) {
 		List<Dependency> deps = new ArrayList<>();
-		deps.add(createActiveMQDependency(runtimeProvider));
+		deps.add(createActiveMQDependency());
 		deps.add(createJMSDependency(runtimeProvider));
 		return deps;
 	}
@@ -71,11 +71,11 @@ public class ActiveMQPaletteEntry implements ICustomPaletteEntry {
 		}
 	}
 
-	private Dependency createActiveMQDependency(String runtimeProvider) {
+	private Dependency createActiveMQDependency() {
 		ActiveMQPaletteEntryDependenciesManager activeMQPaletteEntryDependenciesManager = new ActiveMQPaletteEntryDependenciesManager();
 		return createDependency(
 				ActiveMQPaletteEntryDependenciesManager.ORG_APACHE_ACTIVEMQ,
-				activeMQPaletteEntryDependenciesManager.getArtifactId(runtimeProvider),
+				activeMQPaletteEntryDependenciesManager.getArtifactId(),
 				activeMQPaletteEntryDependenciesManager.getActiveMQVersion(getCurrentProjectCamelVersion()));
 	}
 

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/ActiveMQPaletteEntryDependenciesManager.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/ActiveMQPaletteEntryDependenciesManager.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.fusesource.ide.camel.editor.provider.ext.IDependenciesManager;
-import org.fusesource.ide.camel.model.service.core.util.CamelCatalogUtils;
 import org.fusesource.ide.foundation.core.util.Strings;
 
 public class ActiveMQPaletteEntryDependenciesManager implements IDependenciesManager {
@@ -26,7 +25,6 @@ public class ActiveMQPaletteEntryDependenciesManager implements IDependenciesMan
 	private static final String FUSE_SUFFIX = ".fuse-";
 	static final String ORG_APACHE_ACTIVEMQ = "org.apache.activemq";
 	public static final String ACTIVEMQ_CAMEL = "activemq-camel";
-	public static final String ACTIVEMQ_CAMEL_STARTER = "activemq-camel-starter";
 	
 	// TODO: change me after each release
 	public static final String LATEST_AMQ_VERSION = "5.11.0";
@@ -61,8 +59,7 @@ public class ActiveMQPaletteEntryDependenciesManager implements IDependenciesMan
 
 	private boolean isActiveMQCamelDependency(Dependency dependency) {
 		String artifactId = dependency.getArtifactId();
-		return ORG_APACHE_ACTIVEMQ.equals(dependency.getGroupId())
-				&& (ACTIVEMQ_CAMEL.equals(artifactId) || ACTIVEMQ_CAMEL_STARTER.equals(artifactId));
+		return ORG_APACHE_ACTIVEMQ.equals(dependency.getGroupId()) && ACTIVEMQ_CAMEL.equals(artifactId);
 	}
 
 	String getActiveMQVersion(String camelVersion) {
@@ -102,11 +99,7 @@ public class ActiveMQPaletteEntryDependenciesManager implements IDependenciesMan
 		throw new IllegalArgumentException("Given Camel Version " + camelVersion + " doesn't contain a valid value");
 	}
 
-	public String getArtifactId(String runtimeProvider) {
-		if(CamelCatalogUtils.RUNTIME_PROVIDER_SPRINGBOOT.equals(runtimeProvider)){
-			return ActiveMQPaletteEntryDependenciesManager.ACTIVEMQ_CAMEL_STARTER;
-		} else {
-			return ActiveMQPaletteEntryDependenciesManager.ACTIVEMQ_CAMEL;
-		}
+	public String getArtifactId() {
+		return ActiveMQPaletteEntryDependenciesManager.ACTIVEMQ_CAMEL;
 	}
 }

--- a/editor/tests/org.fusesource.ide.camel.editor.tests.integration/src/main/java/org/fusesource/ide/camel/editor/integration/provider/ToolBehaviourProviderIT.java
+++ b/editor/tests/org.fusesource.ide.camel.editor.tests.integration/src/main/java/org/fusesource/ide/camel/editor/integration/provider/ToolBehaviourProviderIT.java
@@ -149,7 +149,7 @@ public class ToolBehaviourProviderIT {
 		
 		initToolBehaviourProvider();
 		
-		testAMQPalette(ActiveMQPaletteEntryDependenciesManager.ACTIVEMQ_CAMEL_STARTER, ActiveMQPaletteEntry.CAMEL_JMS_STARTER);
+		testAMQPalette(ActiveMQPaletteEntryDependenciesManager.ACTIVEMQ_CAMEL, ActiveMQPaletteEntry.CAMEL_JMS_STARTER);
 	}
 	
 	@Test

--- a/editor/tests/org.fusesource.ide.camel.editor.tests/src/test/java/org/fusesource/ide/camel/editor/provider/ActiveMQPaletteEntryTest.java
+++ b/editor/tests/org.fusesource.ide.camel.editor.tests/src/test/java/org/fusesource/ide/camel/editor/provider/ActiveMQPaletteEntryTest.java
@@ -45,23 +45,23 @@ public class ActiveMQPaletteEntryTest {
 	}
 	
 	@Test
-	public void testGetRequiredDependenciesForSpringBootProvider() throws Exception {
+	public void testGetRequiredDependenciesForSpringBootProviderIsUsingGenericOne() throws Exception {
 		List<Dependency> requiredDependencies = activeMQPaletteEntry.getRequiredDependencies(CamelCatalogUtils.RUNTIME_PROVIDER_SPRINGBOOT);
 		
 		Dependency amqDep = requiredDependencies.get(0);
-		assertThat(amqDep.getArtifactId()).isEqualTo(ActiveMQPaletteEntryDependenciesManager.ACTIVEMQ_CAMEL_STARTER);
+		assertThat(amqDep.getArtifactId()).isEqualTo(ActiveMQPaletteEntryDependenciesManager.ACTIVEMQ_CAMEL);
 		
 		Dependency jmsDep = requiredDependencies.get(1);
 		assertThat(jmsDep.getArtifactId()).isEqualTo("camel-jms-starter");
 	}
 	
 	@Test
-	public void testGetRequiredDependenciesWhenIssueRetrievingCamelVersion() throws Exception {
+	public void testGetRequiredDependenciesWhenIssueRetrievingCamelVersionIsUsingGenericOne() throws Exception {
 		doReturn(null).when(activeMQPaletteEntry).getCurrentProjectCamelVersion();
 		List<Dependency> requiredDependencies = activeMQPaletteEntry.getRequiredDependencies(CamelCatalogUtils.RUNTIME_PROVIDER_SPRINGBOOT);
 		
 		Dependency amqDep = requiredDependencies.get(0);
-		assertThat(amqDep.getArtifactId()).isEqualTo(ActiveMQPaletteEntryDependenciesManager.ACTIVEMQ_CAMEL_STARTER);
+		assertThat(amqDep.getArtifactId()).isEqualTo(ActiveMQPaletteEntryDependenciesManager.ACTIVEMQ_CAMEL);
 		assertThat(amqDep.getVersion()).isEqualTo(ActiveMQPaletteEntryDependenciesManager.LATEST_AMQ_VERSION);
 		
 		Dependency jmsDep = requiredDependencies.get(1);


### PR DESCRIPTION
for Camel 2.x and SrpingBoot, there is no specific -starter artifact for
ActiveMQ. It has been provided for Camel 3.x only. As Eclipse Fuse
Tooling is currently not supporting Camel 3.x, the fix consists in
providing always the non-specific to springboot artifact.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

