### PR TITLE
FUSETOOLS-3327 - remove repository exclusion which is not working

### DIFF
--- a/editor/plugins/org.fusesource.ide.wsdl2rest.ui/pom.xml
+++ b/editor/plugins/org.fusesource.ide.wsdl2rest.ui/pom.xml
@@ -213,17 +213,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<repositories>
-		<repository>
-			<id>jboss.central</id>
-			<url>https://repository.jboss.org/nexus/content/repositories/central/</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
 </project>


### PR DESCRIPTION
it worked locally and few times on Ci but it was by "chance". The
problem was coming from the repository itself. it was an intermittent
problem, depending on which real server the load-balancer was
redirecting. Issue is now fixed on server side.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

