### PR TITLE
FUSETOOLS-3318 - avoid compilation failure after upgrade of target

### DIFF
--- a/core/plugins/org.fusesource.ide.foundation.core/src/org/fusesource/ide/foundation/core/xml/namespace/FindNamespaceHandlerSupport.java
+++ b/core/plugins/org.fusesource.ide.foundation.core/src/org/fusesource/ide/foundation/core/xml/namespace/FindNamespaceHandlerSupport.java
@@ -18,8 +18,12 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
-import org.eclipse.core.internal.content.Activator;
+import org.eclipse.core.internal.content.XMLRootHandler;
 import org.fusesource.ide.foundation.core.internal.FoundationCoreActivator;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -28,8 +32,14 @@ import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 
-
 public class FindNamespaceHandlerSupport extends DefaultHandler {
+
+	private static final BundleContext CONTEXT;
+
+	static {
+		Bundle bundle = FrameworkUtil.getBundle(XMLRootHandler.class);
+		CONTEXT = bundle == null ? null : bundle.getBundleContext();
+	}
 
 	private final Set<String> namespaces;
 	private boolean namespaceFound = false;
@@ -50,7 +60,7 @@ public class FindNamespaceHandlerSupport extends DefaultHandler {
 			throw new StopParsingException();
 		}
 	}
-	
+
 	@Override
 	public void startPrefixMapping(String prefix, String uri) throws SAXException {
 		super.startPrefixMapping(prefix, uri);
@@ -62,33 +72,43 @@ public class FindNamespaceHandlerSupport extends DefaultHandler {
 	}
 
 	public boolean parseContents(InputSource contents) throws IOException, ParserConfigurationException, SAXException {
-		// Parse the file into we have what we need (or an error occurs).
-		try {
-			SAXParserFactory factory = Activator.getDefault().getFactory();
-			if (factory == null)
-				return false;
-			final SAXParser parser = createParser(factory);
-			// to support external entities specified as relative URIs (see bug 63298)
-			contents.setSystemId("/"); //$NON-NLS-1$
-			parser.parse(contents, this);
-		} catch (StopParsingException e) {
-			// Abort the parsing normally. Fall through...
+		if (CONTEXT != null) {
+			ServiceReference<SAXParserFactory> serviceReference = CONTEXT.getServiceReference(SAXParserFactory.class);
+			// Parse the file into we have what we need (or an error occurs).
+			try {
+				SAXParserFactory factory = CONTEXT.getService(serviceReference);
+				if (factory == null)
+					return false;
+				final SAXParser parser = createParser(factory);
+				// to support external entities specified as relative URIs (see bug 63298)
+				contents.setSystemId("/"); //$NON-NLS-1$
+				parser.parse(contents, this);
+			} catch (StopParsingException e) {
+				// Abort the parsing normally. Fall through...
+			} finally {
+				CONTEXT.ungetService(serviceReference);
+			}
+			return true;
+		} else {
+			return false;
 		}
-		return true;
 	}
 
-	private final SAXParser createParser(SAXParserFactory parserFactory) throws ParserConfigurationException, SAXException {
+	private final SAXParser createParser(SAXParserFactory parserFactory)
+			throws ParserConfigurationException, SAXException {
 		parserFactory.setNamespaceAware(true);
 		final SAXParser parser = parserFactory.newSAXParser();
 		final XMLReader reader = parser.getXMLReader();
-		//reader.setProperty("http://xml.org/sax/properties/lexical-handler", this); //$NON-NLS-1$
+		// reader.setProperty("http://xml.org/sax/properties/lexical-handler", this);
+		// //$NON-NLS-1$
 		// disable DTD validation (bug 63625)
 		try {
-			//	be sure validation is "off" or the feature to ignore DTD's will not apply
+			// be sure validation is "off" or the feature to ignore DTD's will not apply
 			reader.setFeature("http://xml.org/sax/features/validation", false); //$NON-NLS-1$
 			reader.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false); //$NON-NLS-1$
 		} catch (SAXNotRecognizedException | SAXNotSupportedException e) {
-			FoundationCoreActivator.pluginLog().logWarning("Exception while trying to determine if the file is an Apache Camel one.", e);
+			FoundationCoreActivator.pluginLog()
+					.logWarning("Exception while trying to determine if the file is an Apache Camel one.", e);
 		}
 		return parser;
 	}


### PR DESCRIPTION
Platform

methods has been moved. See
eclipse/eclipse.platform.runtime@190d65c
.

the bad news is that it seems that we still need to use internal API.

using SaxParserFactory.newInstance() directly is failing several tests
tried to remove (close to) duplicated code with upstream but then it
wasn't working, not found the difference.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

