### PR TITLE
ENTESB-14075 - stop testing templates with latest version

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/CamelCatalogUtils.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/CamelCatalogUtils.java
@@ -144,6 +144,12 @@ public class CamelCatalogUtils {
 		return new ArrayList<>(TEST_CAMEL_VERSIONS);
 	}
 	
+	public static List<String> getCamelVersionsToTestWithForTemplates() {
+		List<String> toTest = new ArrayList<>(TEST_CAMEL_VERSIONS);
+		toTest.remove(CAMEL_VERSION_LATEST_COMMUNITY);
+		return toTest;
+	}
+	
 	public static List<String> getPureFISVersions() {
 		return new ArrayList<>(CAMEL_VERSION_2_FUSE_FIS_BOM_MAPPING.keySet());
 	}

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForAMQIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForAMQIT.java
@@ -29,7 +29,7 @@ public class FuseIntegrationProjectCreatorRunnableForAMQIT extends FuseIntegrati
 
 	@Parameters(name = "{0}")
 	public static List<String> parameters(){
-		return CamelCatalogUtils.getCamelVersionsToTestWith(); 
+		return CamelCatalogUtils.getCamelVersionsToTestWithForTemplates(); 
 	}
 	
 	public FuseIntegrationProjectCreatorRunnableForAMQIT(String version) {

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForCBRIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForCBRIT.java
@@ -30,7 +30,7 @@ public class FuseIntegrationProjectCreatorRunnableForCBRIT extends FuseIntegrati
 
 	@Parameters(name = "{0}")
 	public static List<String> parameters(){
-		return CamelCatalogUtils.getCamelVersionsToTestWith(); 
+		return CamelCatalogUtils.getCamelVersionsToTestWithForTemplates(); 
 	}
 	
 	public FuseIntegrationProjectCreatorRunnableForCBRIT(String version) {

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForCXFCodeFirstIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForCXFCodeFirstIT.java
@@ -32,7 +32,7 @@ public class FuseIntegrationProjectCreatorRunnableForCXFCodeFirstIT extends Fuse
 
 	@Parameters(name = "{0}")
 	public static List<String> parameters(){
-		return CamelCatalogUtils.getCamelVersionsToTestWith(); 
+		return CamelCatalogUtils.getCamelVersionsToTestWithForTemplates(); 
 	}
 	
 	public FuseIntegrationProjectCreatorRunnableForCXFCodeFirstIT(String version) {

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForEAPSpringIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForEAPSpringIT.java
@@ -56,7 +56,7 @@ public class FuseIntegrationProjectCreatorRunnableForEAPSpringIT extends FuseInt
 
 	@Parameters(name = "{0}")
 	public static List<String> parameters(){
-		return CamelCatalogUtils.getCamelVersionsToTestWith();
+		return CamelCatalogUtils.getCamelVersionsToTestWithForTemplates();
 	}
 	
 	public FuseIntegrationProjectCreatorRunnableForEAPSpringIT(String version) {

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForOSESringBootIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForOSESringBootIT.java
@@ -36,7 +36,7 @@ public class FuseIntegrationProjectCreatorRunnableForOSESringBootIT extends Fuse
 	
 	@Parameters(name = "{0}")
 	public static List<String> parameters(){
-		return Arrays.asList(CamelCatalogUtils.CAMEL_VERSION_LATEST_FIS_20, CamelCatalogUtils.CAMEL_VERSION_LATEST_COMMUNITY, CamelForFuseOnOpenShiftToBomMapper.FUSE_760_CAMEL_VERSION);
+		return Arrays.asList(CamelCatalogUtils.CAMEL_VERSION_LATEST_FIS_20, CamelForFuseOnOpenShiftToBomMapper.FUSE_760_CAMEL_VERSION);
 	}
 	
 	public FuseIntegrationProjectCreatorRunnableForOSESringBootIT(String camelVersion) {

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForSimpleIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForSimpleIT.java
@@ -38,7 +38,7 @@ public class FuseIntegrationProjectCreatorRunnableForSimpleIT extends FuseIntegr
 	
 	@Parameters(name = "{0}")
 	public static List<String> parameters(){
-		return CamelCatalogUtils.getCamelVersionsToTestWith(); 
+		return CamelCatalogUtils.getCamelVersionsToTestWithForTemplates(); 
 	}
 	
 	public FuseIntegrationProjectCreatorRunnableForSimpleIT(String version) {


### PR DESCRIPTION
- Fuse runtime is not providing anymore valid artifacts for that and
doesn't want to set it back.
- this is just removal of the test, the problem still exists for
end-users. A cleaner way would be to remove mechanic to look to online
versions, which would remove a great feature for testing against
unreleased version.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request Checklist

After this checklist is all checked or PR provides explanations for possible pass-through, please put the label "Ready for review" on the PR.


## General

- [ ] Did you use the Jira Issue number in the commit comments?
- [ ] Did you set meaningful commit comments on each commit?
- [ ] Did you sign off all commits for this PR? (git commit -s -m "jira issue number - your commit comment")

## Functional

- [ ] Did the CI job report a successful build?
- [ ] Is the non-happy path working, too?

## Maintainability

- [ ] Are all Sonar reported issues fixed or can they be ignored?
- [ ] Is there no duplicated code?
- [ ] Are method-/class-/variable-names meaningful?

## Tests

- [ ] Are there unit-tests?
- [ ] Are there integration tests (or at least a jira to tackle these)?
- [ ] Do we need a new UI test?

## Legal

- [ ] Have you used the correct file header copyright comment?
- [ ] Have you used the correct year in the headers of new files?

