### PR TITLE
FUSETOOLS-3368 - fix feature

### DIFF
--- a/core/features/org.fusesource.ide.core.feature/feature.xml
+++ b/core/features/org.fusesource.ide.core.feature/feature.xml
@@ -251,7 +251,7 @@
          unpack="false"/>
 
    <plugin
-         id="org.fusesource.ide.camel.model.service.impl.v2233"
+         id="org.fusesource.ide.camel.model.service.impl.v2232fuse770010redhat00001"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
was referencing the wrong plugin id

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

