### PR TITLE
Avoid empty system editor to open in tests

### DIFF
--- a/editor/tests/org.fusesource.ide.branding.tests.integration/src/main/java/org/fusesource/ide/branding/tests/integration/wizards/AbstractNewCamelTestWizardIT.java
+++ b/editor/tests/org.fusesource.ide.branding.tests.integration/src/main/java/org/fusesource/ide/branding/tests/integration/wizards/AbstractNewCamelTestWizardIT.java
@@ -11,7 +11,14 @@
 package org.fusesource.ide.branding.tests.integration.wizards;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
@@ -28,22 +35,11 @@ import org.fusesource.ide.branding.wizards.NewCamelTestWizard;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
 import org.fusesource.ide.camel.model.service.core.tests.integration.core.io.FuseProject;
 import org.junit.Rule;
-import org.junit.Test;
 
-public class NewCamelTestWizardIT {
+public abstract class AbstractNewCamelTestWizardIT {
 	
 	@Rule
-	public FuseProject fuseProject = new FuseProject(NewCamelTestWizardIT.class.getSimpleName());
-	
-	@Test
-	public void testCreateTestForRouteUsingCamelContext() throws Exception {
-		createTestFor(fuseProject.createEmptyCamelFile());
-	}
-	
-	@Test
-	public void testCreateTestForRouteUsingRoutesForContainer() throws Exception {
-		createTestFor(fuseProject.createEmptyCamelFileWithRoutes());
-	}
+	public FuseProject fuseProject = new FuseProject(getClass().getSimpleName());
 
 	@SuppressWarnings("restriction")
 	protected void createTestFor(CamelFile camelFile) throws CoreException {
@@ -63,7 +59,14 @@ public class NewCamelTestWizardIT {
 		newTypeWizardPage.setTypeName("UniqueTestClassNameTest", false);
 		assertThat(newCamelTestWizard.performFinish()).isTrue();
 		
-		assertThat(project.getFile(new Path("src/test/java/UniqueTestClassNameTest.java")).getLocation().toFile()).exists();
+		IFile testIfile = project.getFile(new Path("src/test/java/UniqueTestClassNameTest.java"));
+		File testFile = testIfile.getLocation().toFile();
+		assertTrue(testFile.exists());
+		BufferedReader reader = new BufferedReader(new InputStreamReader(testIfile.getContents()));
+		String contentOfTestFile = reader.lines().collect(Collectors.joining("\n"));
+		assertThat(contentOfTestFile).contains("class UniqueTestClassNameTest");
+		
+		wizardDialog.close();
 	}
 
 }

--- a/editor/tests/org.fusesource.ide.branding.tests.integration/src/main/java/org/fusesource/ide/branding/tests/integration/wizards/NewCamelTestWizardWithCamelContextIT.java
+++ b/editor/tests/org.fusesource.ide.branding.tests.integration/src/main/java/org/fusesource/ide/branding/tests/integration/wizards/NewCamelTestWizardWithCamelContextIT.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.fusesource.ide.branding.tests.integration.wizards;
+
+import org.junit.Test;
+
+public class NewCamelTestWizardWithCamelContextIT extends AbstractNewCamelTestWizardIT {
+	
+	@Test
+	public void testCreateTestForRouteUsingCamelContext() throws Exception {
+		createTestFor(fuseProject.createEmptyCamelFile());
+	}
+}

--- a/editor/tests/org.fusesource.ide.branding.tests.integration/src/main/java/org/fusesource/ide/branding/tests/integration/wizards/NewCamelTestWizardWithRoutesIT.java
+++ b/editor/tests/org.fusesource.ide.branding.tests.integration/src/main/java/org/fusesource/ide/branding/tests/integration/wizards/NewCamelTestWizardWithRoutesIT.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.fusesource.ide.branding.tests.integration.wizards;
+
+import org.junit.Test;
+
+public class NewCamelTestWizardWithRoutesIT extends AbstractNewCamelTestWizardIT {
+	
+	@Test
+	public void testCreateTestForRouteUsingRoutesForContainer() throws Exception {
+		createTestFor(fuseProject.createEmptyCamelFileWithRoutes());
+	}
+}


### PR DESCRIPTION
- had to split the test to have 2 differents projects (FuseProject rule)
used
- added a small additional check on the content of the file
- added to close the WizardDialog at the end of the test to have cleaner
test

The Java editor doesn't seem to be opened in the test. Not sure why.
