### PR TITLE
Fusetools 3393 use local vm debug

### DIFF
--- a/core/tests/org.fusesource.ide.camel.tests.util/src/org/fusesource/ide/camel/tests/util/JDKInstaller.java
+++ b/core/tests/org.fusesource.ide.camel.tests.util/src/org/fusesource/ide/camel/tests/util/JDKInstaller.java
@@ -23,9 +23,9 @@ public class JDKInstaller {
 
 	public IVMInstall installJDK8(IVMInstallType vmInstallType) {
 		IVMInstall vmInstall = vmInstallType.createVMInstall(JDK8_VMINSTALL_NAME);
-		vmInstall.setName(JDK8_VMINSTALL_NAME);
 		File jdk8home = findJDK8VM();
 		vmInstall.setInstallLocation(jdk8home);
+		vmInstall.setName(JDK8_VMINSTALL_NAME);
 		return vmInstall;
 	}
 

--- a/editor/plugins/org.fusesource.ide.camel.editor/META-INF/MANIFEST.MF
+++ b/editor/plugins/org.fusesource.ide.camel.editor/META-INF/MANIFEST.MF
@@ -33,7 +33,8 @@ Export-Package: org.fusesource.ide.camel.editor,
  org.fusesource.ide.camel.editor.restconfiguration.actions,
  org.fusesource.ide.camel.editor.utils
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.ui.ide;bundle-version="3.10.0",
+Require-Bundle: org.jboss.tools.common.jaxb;resolution:=optional,
+ org.eclipse.ui.ide;bundle-version="3.10.0",
  org.eclipse.core.databinding;bundle-version="1.4.1",
  org.eclipse.debug.core;bundle-version="3.9.0",
  org.eclipse.emf.transaction;bundle-version="1.8.0",
@@ -64,7 +65,6 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="3.10.0",
  org.fusesource.ide.camel.model.service.impl;bundle-version="10.0.0",
  org.eclipse.core.databinding.beans;bundle-version="1.3.0",
  org.eclipse.core.databinding.property;bundle-version="1.5.0",
- org.jboss.tools.common.jaxb;resolution:=optional,
  org.eclipse.wildwebdeveloper.xml;bundle-version="0.9.1",
  org.eclipse.ui.genericeditor;bundle-version="1.1.700",
  org.eclipse.ui.editors;bundle-version="3.13.300"

--- a/editor/plugins/org.fusesource.ide.launcher.ui/OSGI-INF/l10n/bundle.properties
+++ b/editor/plugins/org.fusesource.ide.launcher.ui/OSGI-INF/l10n/bundle.properties
@@ -23,5 +23,5 @@ command.variables.injectheader.name=Add Header
 command.variables.injectheader.description=Adds a new header to the message...
 command.variables.delete.name=Delete
 command.variables.delete.description=Deletes the variable...
-tabgroup.remote.camelandjava.description=Update settings to connect to a remote Camel Context and Java vm
-tabgroup.remote.camel.description=Update settings to connect to a remote Camel Context
+tabgroup.remote.camelandjava.description=Update settings to connect to a remote Camel Context (up to Fuse 7.7) and Java vm
+tabgroup.remote.camel.description=Update settings to connect to a remote Camel Context (up to Fuse 7.7)

--- a/editor/plugins/org.fusesource.ide.launcher/META-INF/MANIFEST.MF
+++ b/editor/plugins/org.fusesource.ide.launcher/META-INF/MANIFEST.MF
@@ -23,7 +23,10 @@ Require-Bundle: org.eclipse.jdt.launching,
  org.eclipse.osgi.services;bundle-version="3.5.0",
  org.eclipse.e4.core.services;bundle-version="2.0.0",
  org.fusesource.ide.jmx.commons;bundle-version="10.0.0",
- org.eclipse.m2e.maven.runtime;bundle-version="1.6.2"
+ org.eclipse.m2e.maven.runtime;bundle-version="1.6.2",
+ org.jboss.tools.jmx.jvmmonitor.core,
+ org.eclipse.debug.core,
+ org.jboss.tools.jmx.local;bundle-version="1.10.111"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.fusesource.ide.launcher.Activator
 Export-Package: org.fusesource.ide.launcher,

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelDebugFacade.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelDebugFacade.java
@@ -39,7 +39,7 @@ public class CamelDebugFacade implements ICamelDebuggerMBeanFacade {
 	private static final String CAMEL_CONTEXT_MBEAN = "org.apache.camel:type=context,name=\"%s\",*";
 	
 	
-	private static final long TIMEOUT_MBEAN_REGISTRATION = JMXCamelConnectJob.CONNECTION_TIMEOUT_IN_MILLIS + 30 * 1000L;
+	private static final long TIMEOUT_MBEAN_REGISTRATION = JMXCamelConnectJob.CONNECTION_TIMEOUT_IN_MILLIS + 5 * 60 * 1000L;
 	
 	private ObjectName objectNameDebugger = null;
 	private ObjectName objectNameContext = null;

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelDebugFacade.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelDebugFacade.java
@@ -39,7 +39,7 @@ public class CamelDebugFacade implements ICamelDebuggerMBeanFacade {
 	private static final String CAMEL_CONTEXT_MBEAN = "org.apache.camel:type=context,name=\"%s\",*";
 	
 	
-	private static final long TIMEOUT_MBEAN_REGISTRATION = 30 * 1000L; // 30 secs
+	private static final long TIMEOUT_MBEAN_REGISTRATION = JMXCamelConnectJob.CONNECTION_TIMEOUT_IN_MILLIS + 30 * 1000L;
 	
 	private ObjectName objectNameDebugger = null;
 	private ObjectName objectNameContext = null;

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/EventDispatchJob.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/EventDispatchJob.java
@@ -49,7 +49,10 @@ class EventDispatchJob extends Job {
 
 	private void checkSuspendedBreakpoints() {
 		ICamelDebuggerMBeanFacade debugger = camelDebugTarget.getDebugger();
-		if (debugger != null && !camelDebugTarget.isSuspended()) {
+		if (debugger != null
+				&& !camelDebugTarget.isSuspended()
+				&& !camelDebugTarget.isDisconnected()
+				&& !camelDebugTarget.isTerminated()) {
 			try {
 				Set<String> suspendedBreakpoints = debugger.getSuspendedBreakpointNodeIds();
 				if (suspendedBreakpoints != null && !suspendedBreakpoints.isEmpty()) {

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/JMXCamelConnectJob.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/JMXCamelConnectJob.java
@@ -47,7 +47,7 @@ public class JMXCamelConnectJob extends Job {
 	private String jmxUser;
 	private String jmxPass;
 	
-	private static final long CONNECTION_TIMEOUT_IN_MILLIS = 1000 * 60 * 10L; // 10 minutes timeout
+	public static final long CONNECTION_TIMEOUT_IN_MILLIS = 1000 * 60 * 10L; // 10 minutes timeout
 	
 	public JMXCamelConnectJob(CamelDebugTarget camelDebugTarget) {
 		super("Connect to Camel Debugger...");
@@ -140,7 +140,7 @@ public class JMXCamelConnectJob extends Job {
 		}
 	}
 
-	private MBeanServerConnection createMBeanServerConnection(IConnectionWrapper jmxConnectionWrapper) throws IOException, JMXException {
+	public MBeanServerConnection createMBeanServerConnection(IConnectionWrapper jmxConnectionWrapper) throws IOException, JMXException {
 		if(!jmxConnectionWrapper.isConnected()){
 			jmxConnectionWrapper.connect();
 		}

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/run/launching/FuseMavenLaunchDelegate.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/run/launching/FuseMavenLaunchDelegate.java
@@ -120,7 +120,7 @@ public abstract class FuseMavenLaunchDelegate extends MavenLaunchDelegate {
 		sb.append(" -DECLIPSE_PROCESS_NAME=\"'" + getEclipseProcessName() + "'\"");
 		// switch the test flag
 		sb.append(" -Dmaven.test.skip=" + this.skipTests);
-		// enable jmx
+		// enable JMX RMI Connector - allows remote debug for Fuse 7.8-
 		sb.append(" -Dorg.apache.camel.jmx.createRmiConnector=True");
 		
 		return sb.toString();

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableIT.java
@@ -138,9 +138,7 @@ public abstract class FuseIntegrationProjectCreatorRunnableIT extends AbstractPr
 			if(!(metadata.getTemplate() instanceof AbstractEAPSpringTemplate)) {
 				checkRunAsMenuAvailable(project);
 			}
-			if(!(metadata.getCamelVersion().startsWith("2.23.2.fuse-780"))) {
-				launchDebug(project);
-			}
+			launchDebug(project);
 		} else {
 			//TODO: different Run? or implement the java local camel context?
 		}


### PR DESCRIPTION
requires https://github.com/jbosstools/jbosstools-fuse/pull/1639
(and https://github.com/jbosstools/jbosstools-base/pull/684 )

tested:
- local debug with Fuse 7.7 and Fuse 7.8 using "Debug as..." -> Local Camel Context --> working
- using local Jolokia connection with Fuse 7.8 --> working
- Camel on Fuse Karaf -> working
- automated test checking remote debug still working with old Camel versions already available

started to test:
- debug when deployed on OpenShift (using remote secured Jolokia). hit several known issues in Jboss Tools (reported 2 or 3 years ago)

not tested:
- Camel on EAP but similar code than for Fuse on Karaf
