### PR TITLE
FUSETOOLS-3394 - upgrade grrovy lib to support JDK 14+

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.impl/.classpath
+++ b/core/plugins/org.fusesource.ide.camel.model.service.impl/.classpath
@@ -17,7 +17,7 @@
 	<classpathentry exported="true" kind="lib" path="libs/log4j-over-slf4j-1.7.26.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/slf4j-api-1.7.26.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/slf4j-simple-1.7.26.jar"/>
-	<classpathentry exported="true" kind="lib" path="libs/groovy-2.5.5.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/groovy-2.5.14.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/ivy-2.4.0.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/core/plugins/org.fusesource.ide.camel.model.service.impl/META-INF/MANIFEST.MF
+++ b/core/plugins/org.fusesource.ide.camel.model.service.impl/META-INF/MANIFEST.MF
@@ -28,7 +28,7 @@ Bundle-ClassPath: .,
  libs/log4j-over-slf4j-1.7.26.jar,
  libs/slf4j-api-1.7.26.jar,
  libs/slf4j-simple-1.7.26.jar,
- libs/groovy-2.5.5.jar,
+ libs/groovy-2.5.14.jar,
  libs/ivy-2.4.0.jar
 Export-Package: org.fusesource.ide.camel.model.service.impl,
  org.fusesource.ide.camel.model.service.internal;x-friends:="org.fusesource.ide.camel.tests.util,org.fusesource.ide.camel.model.service.impl.tests.integration"

--- a/core/plugins/org.fusesource.ide.camel.model.service.impl/build.properties
+++ b/core/plugins/org.fusesource.ide.camel.model.service.impl/build.properties
@@ -13,7 +13,7 @@ bin.includes = META-INF/,\
                libs/log4j-over-slf4j-1.7.26.jar,\
                libs/slf4j-api-1.7.26.jar,\
                libs/slf4j-simple-1.7.26.jar,\
-               libs/groovy-2.5.5.jar,\
+               libs/groovy-2.5.14.jar,\
                libs/ivy-2.4.0.jar,\
                plugin.xml
 

--- a/core/plugins/org.fusesource.ide.camel.model.service.impl/pom.xml
+++ b/core/plugins/org.fusesource.ide.camel.model.service.impl/pom.xml
@@ -18,7 +18,7 @@
   <properties>
   		<bundle.camel.version>2.24.1</bundle.camel.version>
   		<bundle.slf4j.version>1.7.26</bundle.slf4j.version>
-  		<groovy-version>2.5.5</groovy-version>
+  		<groovy-version>2.5.14</groovy-version>
   		<ivy-version>2.4.0</ivy-version>
   </properties>
   <build>


### PR DESCRIPTION
the groovy lib doesn't match the camel version but this version has been
provided on Camel 2.25.x branch and it is working well so good chance
that it is not causing any problems.
JRE 15 is now shipped by default in Eclipse

