### PR TITLE
Use classname.methodName as project name if not specified

### DIFF
--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/java/org/fusesource/ide/camel/model/service/core/tests/integration/core/io/FuseProject.java
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/java/org/fusesource/ide/camel/model/service/core/tests/integration/core/io/FuseProject.java
@@ -38,6 +38,8 @@ import org.fusesource.ide.camel.model.service.core.model.CamelFile;
 import org.fusesource.ide.camel.model.service.core.tests.integration.core.CamelModelServiceIntegrationTestActivator;
 import org.fusesource.ide.camel.model.service.core.util.CamelCatalogUtils;
 import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 /**
  * @author Aurelien Pupier
@@ -53,6 +55,10 @@ public class FuseProject extends ExternalResource {
 	private String camelVersion;
 	private boolean isBlueprint = false;
 
+	public FuseProject() {
+		this(null, CamelCatalogUtils.getLatestCamelVersion());
+	}
+	
 	public FuseProject(String projectName) {
 		this(projectName, CamelCatalogUtils.getLatestCamelVersion());
 	}
@@ -70,6 +76,14 @@ public class FuseProject extends ExternalResource {
 	public FuseProject(String projectName, String camelVersion, boolean isBlueprint) {
 		this(projectName, camelVersion);
 		this.isBlueprint = isBlueprint;
+	}
+	
+	@Override
+	public Statement apply(Statement base, Description description) {
+		if(projectName == null) {
+			projectName = description.getClassName() + "." + description.getMethodName();
+		}
+		return super.apply(base, description);
 	}
 
 	@Override

--- a/editor/tests/org.fusesource.ide.camel.editor.tests.integration/src/main/java/org/fusesource/ide/camel/editor/integration/provider/ToolBehaviourProviderIT.java
+++ b/editor/tests/org.fusesource.ide.camel.editor.tests.integration/src/main/java/org/fusesource/ide/camel/editor/integration/provider/ToolBehaviourProviderIT.java
@@ -59,7 +59,7 @@ public class ToolBehaviourProviderIT {
 	private ToolBehaviourProvider toolbehaviourprovider;
 	
 	@Rule
-	public FuseProject fuseProject = new FuseProject(ToolBehaviourProviderIT.class.getName());
+	public FuseProject fuseProject = new FuseProject();
 	
 	private static final String DUMMY_POM_CONTENT_WITH_SPRING_BOOT_DEPENDENCY = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
 			+ "<project xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\" xmlns=\"http://maven.apache.org/POM/4.0.0\"\n"

--- a/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests.integration/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/util/ImportExportPackageUpdaterForPomIT.java
+++ b/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests.integration/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/util/ImportExportPackageUpdaterForPomIT.java
@@ -166,7 +166,7 @@ public class ImportExportPackageUpdaterForPomIT {
 			POM_END;
 
 	@Rule
-	public FuseProject fuseProject = new FuseProject(ImportExportPackageUpdaterForPomIT.class.getName());
+	public FuseProject fuseProject = new FuseProject();
 
 	private IProject project;
 	private IFile pomIFile;


### PR DESCRIPTION
It allows to ensure unique names and avoid tests affecting each others.

