### PR TITLE
FUSETOOLS2-978 - remove syncExec block to avoid potential jobs deadlock

### DIFF
--- a/core/plugins/org.fusesource.ide.preferences/src/org/fusesource/ide/preferences/initializer/PreferencesInitializer.java
+++ b/core/plugins/org.fusesource.ide.preferences/src/org/fusesource/ide/preferences/initializer/PreferencesInitializer.java
@@ -42,9 +42,7 @@ public class PreferencesInitializer extends AbstractPreferenceInitializer {
 		store.setDefault(PreferencesConstants.EDITOR_FIGURE_FG_COLOR, "128,128,128");
 		store.setDefault(PreferencesConstants.EDITOR_TEXT_COLOR, "0,0,0");
 
-		Display.getDefault().syncExec( () -> {
-			Color c = Display.getDefault().getSystemColor(SWT.COLOR_WIDGET_LIGHT_SHADOW);
-			store.setDefault(PreferencesConstants.EDITOR_TABLE_CHART_BG_COLOR, String.format("%d,%d,%d", c.getRed(), c.getGreen(), c.getBlue()));				
-		});
+		Color c = Display.getDefault().getSystemColor(SWT.COLOR_WIDGET_LIGHT_SHADOW);
+		store.setDefault(PreferencesConstants.EDITOR_TABLE_CHART_BG_COLOR, String.format("%d,%d,%d", c.getRed(), c.getGreen(), c.getBlue()));				
 	}
 }


### PR DESCRIPTION
the syncExec was introduced here https://github.com/jbosstools/jbosstools-fuse/commit/a8b68f44442082ad2a07fa12b1049b3d2b2aa9fe#r46963310

the preference value is used fo rinstance when starting a route. Connecting through JMX Navigator, select a setBody, In properties view, select processors

to avoid this kind of stacks:

```
!ENTRY org.eclipse.ui 4 4 2021-02-09 04:01:15.611
!MESSAGE To avoid deadlock while executing Display.syncExec() with argument: org.fusesource.ide.preferences.initializer.PreferencesInitializer$$Lambda$714/0x0000000100d12040@4eba3b82, thread Worker-3: Synchronizing projects will interrupt UI thread.
!SUBENTRY 1 org.eclipse.ui 4 4 2021-02-09 04:01:15.611
!MESSAGE Worker-3: Synchronizing projects thread is an instance of Worker or owns an ILock
!STACK 0
java.lang.IllegalStateException: Call stack for thread Worker-3: Synchronizing projects
	at java.management@11.0.10/sun.management.ThreadImpl.dumpThreads0(Native Method)
	at java.management@11.0.10/sun.management.ThreadImpl.getThreadInfo(ThreadImpl.java:485)
	at org.eclipse.ui.internal.UILockListener.reportInterruption(UILockListener.java:209)
	at org.eclipse.ui.internal.UILockListener.interruptUI(UILockListener.java:179)
	at org.eclipse.ui.internal.PendingSyncExec.waitUntilExecuted(PendingSyncExec.java:92)
	at org.eclipse.ui.internal.UISynchronizer.syncExec(UISynchronizer.java:142)
	at org.eclipse.swt.widgets.Display.syncExec(Display.java:5855)
	at org.fusesource.ide.preferences.initializer.PreferencesInitializer.initializeDefaultPreferences(PreferencesInitializer.java:45)
	at org.eclipse.core.internal.preferences.PreferenceServiceRegistryHelper$1.run(PreferenceServiceRegistryHelper.java:307)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.core.internal.preferences.PreferenceServiceRegistryHelper.runInitializer(PreferenceServiceRegistryHelper.java:310)
	at org.eclipse.core.internal.preferences.PreferenceServiceRegistryHelper.applyRuntimeDefaults(PreferenceServiceRegistryHelper.java:134)
	at org.eclipse.core.internal.preferences.PreferencesService.applyRuntimeDefaults(PreferencesService.java:374)
	at org.eclipse.core.internal.preferences.DefaultPreferences.applyRuntimeDefaults(DefaultPreferences.java:225)
	at org.eclipse.core.internal.preferences.DefaultPreferences.load(DefaultPreferences.java:279)
	at org.eclipse.core.internal.preferences.EclipsePreferences.create(EclipsePreferences.java:370)
	at org.eclipse.core.internal.preferences.EclipsePreferences.internalNode(EclipsePreferences.java:624)
	at org.eclipse.core.internal.preferences.EclipsePreferences.node(EclipsePreferences.java:767)
	at org.eclipse.core.internal.preferences.AbstractScope.getNode(AbstractScope.java:41)
	at org.eclipse.core.runtime.preferences.DefaultScope.getNode(DefaultScope.java:77)
	at org.eclipse.ui.preferences.ScopedPreferenceStore.getDefaultPreferences(ScopedPreferenceStore.java:222)
	at org.eclipse.ui.preferences.ScopedPreferenceStore.getPreferenceNodes(ScopedPreferenceStore.java:251)
	at org.eclipse.ui.preferences.ScopedPreferenceStore.internalGet(ScopedPreferenceStore.java:389)
	at org.eclipse.ui.preferences.ScopedPreferenceStore.getBoolean(ScopedPreferenceStore.java:333)
	at org.fusesource.ide.preferences.initializer.StagingRepositoriesPreferenceInitializer.isStagingRepositoriesEnabled(StagingRepositoriesPreferenceInitializer.java:66)
	at org.fusesource.ide.preferences.StagingRepositoriesUtils.getAdditionalRepos(StagingRepositoriesUtils.java:34)
	at org.fusesource.ide.camel.model.service.internal.DynamicCamelCatalog.configureAdditionalRepos(DynamicCamelCatalog.java:52)
	at org.fusesource.ide.camel.model.service.internal.DynamicCamelCatalog.<init>(DynamicCamelCatalog.java:47)
	at org.fusesource.ide.camel.model.service.internal.CamelService.createCatalogForNotEmbeddedVersions(CamelService.java:85)
	at org.fusesource.ide.camel.model.service.internal.CamelService.getCatalog(CamelService.java:65)
	at org.fusesource.ide.camel.model.service.internal.CamelService.updateMavenRepositoryLookup(CamelService.java:179)
	at org.fusesource.ide.camel.model.service.core.catalog.cache.CamelCatalogCacheManager.getCamelModelForProject(CamelCatalogCacheManager.java:131)
	at org.fusesource.ide.camel.model.service.core.util.ProjectClasspathChangedListener.notifyClasspathChanged(ProjectClasspathChangedListener.java:156)
	at org.fusesource.ide.camel.model.service.core.util.ProjectClasspathChangedListener.visit(ProjectClasspathChangedListener.java:134)
	at org.fusesource.ide.camel.model.service.core.util.ProjectClasspathChangedListener.visitChildren(ProjectClasspathChangedListener.java:89)
	at org.fusesource.ide.camel.model.service.core.util.ProjectClasspathChangedListener.visit(ProjectClasspathChangedListener.java:130)
	at org.fusesource.ide.camel.model.service.core.util.ProjectClasspathChangedListener.elementChanged(ProjectClasspathChangedListener.java:62)
	at org.eclipse.jdt.internal.core.DeltaProcessor$3.run(DeltaProcessor.java:1755)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.jdt.internal.core.DeltaProcessor.notifyListeners(DeltaProcessor.java:1743)
	at org.eclipse.jdt.internal.core.DeltaProcessor.firePostChangeDelta(DeltaProcessor.java:1576)
	at org.eclipse.jdt.internal.core.DeltaProcessor.fire(DeltaProcessor.java:1552)
	at org.eclipse.jdt.internal.core.DeltaProcessor.notifyAndFire(DeltaProcessor.java:2273)
	at org.eclipse.jdt.internal.core.DeltaProcessor.resourceChanged(DeltaProcessor.java:2163)
	at org.eclipse.jdt.internal.core.DeltaProcessingState.resourceChanged(DeltaProcessingState.java:477)
	at org.eclipse.core.internal.events.NotificationManager$1.run(NotificationManager.java:305)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.core.internal.events.NotificationManager.notify(NotificationManager.java:295)
	at org.eclipse.core.internal.events.NotificationManager.broadcastChanges(NotificationManager.java:158)
	at org.eclipse.core.internal.resources.Workspace.broadcastPostChange(Workspace.java:380)
	at org.eclipse.core.internal.resources.Workspace.endOperation(Workspace.java:1502)
	at org.eclipse.core.internal.resources.InternalWorkspaceJob.run(InternalWorkspaceJob.java:49)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
!SUBENTRY 1 org.eclipse.ui 4 4 2021-02-09 04:01:15.611
!MESSAGE UI thread waiting on a job or lock.
!STACK 0
java.lang.IllegalStateException: Call stack for thread main
	at java.base@11.0.10/java.lang.Object.wait(Native Method)
	at org.eclipse.core.internal.jobs.Semaphore.acquire(Semaphore.java:44)
	at org.eclipse.core.internal.jobs.OrderedLock.doAcquire(OrderedLock.java:173)
	at org.eclipse.core.internal.jobs.OrderedLock.acquire(OrderedLock.java:109)
	at org.eclipse.core.internal.jobs.OrderedLock.acquire(OrderedLock.java:85)
	at org.eclipse.core.internal.resources.WorkManager.checkIn(WorkManager.java:125)
	at org.eclipse.core.internal.resources.Workspace.prepareOperation(Workspace.java:2242)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2287)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2317)
	at org.eclipse.jdt.internal.core.JavaModelOperation.runOperation(JavaModelOperation.java:807)
	at org.eclipse.jdt.core.JavaCore.setClasspathContainer(JavaCore.java:5965)
	at org.eclipse.m2e.jdt.internal.BuildPathManager.updateClasspath(BuildPathManager.java:209)
	at org.eclipse.m2e.jdt.internal.AbstractJavaProjectConfigurator.configure(AbstractJavaProjectConfigurator.java:180)
	at org.eclipse.m2e.core.project.configurator.AbstractLifecycleMapping.configure(AbstractLifecycleMapping.java:122)
	at org.eclipse.m2e.core.internal.project.ProjectConfigurationManager.lambda$2(ProjectConfigurationManager.java:511)
	at org.eclipse.m2e.core.internal.project.ProjectConfigurationManager$$Lambda$683/0x0000000100c75440.call(Unknown Source)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:179)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:153)
	at org.eclipse.m2e.core.internal.project.ProjectConfigurationManager.updateProjectConfiguration(ProjectConfigurationManager.java:505)
	at org.eclipse.m2e.core.internal.project.ProjectConfigurationManager.configureNewMavenProjects(ProjectConfigurationManager.java:296)
	at org.eclipse.m2e.core.internal.project.ProjectConfigurationManager$1.run(ProjectConfigurationManager.java:530)
	at org.eclipse.m2e.core.internal.embedder.AbstractRunnable.call(AbstractRunnable.java:28)
	at org.eclipse.m2e.core.internal.embedder.AbstractRunnable.call(AbstractRunnable.java:1)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:179)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:153)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:101)
	at org.eclipse.m2e.core.internal.embedder.MavenImpl.execute(MavenImpl.java:1374)
	at org.eclipse.m2e.core.internal.project.ProjectConfigurationManager.enableMavenNature(ProjectConfigurationManager.java:527)
	at org.fusesource.ide.camel.model.service.core.tests.integration.core.io.FuseProject.enableMavenNature(FuseProject.java:130)
	at org.fusesource.ide.camel.model.service.core.tests.integration.core.io.FuseProject.before(FuseProject.java:121)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:50)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at java.base@11.0.10/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base@11.0.10/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base@11.0.10/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base@11.0.10/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:206)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:161)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:84)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:113)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication$1.run(AbstractUITestApplication.java:35)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:185)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4988)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4510)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1157)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1046)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:155)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:644)
	at org.eclipse.ui.internal.Workbench$$Lambda$123/0x0000000100301440.run(Unknown Source)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:551)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:153)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:150)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:401)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at java.base@11.0.10/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base@11.0.10/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base@11.0.10/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base@11.0.10/java.lang.reflect.Method.invoke(Method.java:566)
	at app//org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:657)
	at app//org.eclipse.equinox.launcher.Main.basicRun(Main.java:594)
	at app//org.eclipse.equinox.launcher.Main.run(Main.java:1465)
	at app//org.eclipse.equinox.launcher.Main.main(Main.java:1438)
	```