### PR TITLE
FUSETOOLS2-980 - backup workspace log for UI test failure

### DIFF
--- a/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/src/org/jboss/tools/fuse/ui/bot/tests/DefaultTest.java
+++ b/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/src/org/jboss/tools/fuse/ui/bot/tests/DefaultTest.java
@@ -10,8 +10,12 @@
  ******************************************************************************/
 package org.jboss.tools.fuse.ui.bot.tests;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.reddeer.common.logging.Logger;
 import org.eclipse.reddeer.common.matcher.RegexMatcher;
 import org.eclipse.reddeer.common.wait.TimePeriod;
@@ -32,6 +36,8 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestWatcher;
 
 /**
  * Prepares environment for tests
@@ -41,6 +47,20 @@ import org.junit.BeforeClass;
 public class DefaultTest {
 
 	private static Logger log = Logger.getLogger(DefaultTest.class);
+	
+	@Rule
+	public final TestWatcher watchman = new TestWatcher() {
+		
+		@Override
+		protected void failed(Throwable e, org.junit.runner.Description description) {
+			Path logFile = Platform.getLogFileLocation().toFile().toPath();
+			try {
+				Files.copy(logFile, logFile.resolveSibling(description.getClassName() + "."+description.getMethodName()+".log"));
+			} catch (IOException ex) {
+				log.error("Cannot backup workspace log file", ex);
+			}
+		}
+	};
 
 	/**
 	 * Prepares test environment


### PR DESCRIPTION
Given that DefaultTest.defaultSetup() is deletign workspace log, copying
it in case of test failure with anothe rname to have it available for
investigation

