### PR TITLE
FUSETOOLS2-396 - use different name for each test

### DIFF
--- a/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests.integration/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/util/ImportExportPackageUpdaterForManifestIT.java
+++ b/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests.integration/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/util/ImportExportPackageUpdaterForManifestIT.java
@@ -73,7 +73,7 @@ public class ImportExportPackageUpdaterForManifestIT {
 	
 
 	@Rule
-	public FuseProject fuseProject = new FuseProject(ImportExportPackageUpdaterForManifestIT.class.getName());
+	public FuseProject fuseProject = new FuseProject();
 	
 	private IProject project;
 	private IFile pomIFile;


### PR DESCRIPTION
to ensure that they are not affecting each other and it is not the cause
of potential flaky test

