### PR TITLE
FUSETOOLS-3441 - launch only non-templates integration test by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,9 +270,9 @@
 
 	<profiles>
 		<profile>
-			<id>default-integration-test</id>
+			<id>all-integration-test</id>
 			<activation>
-				<activeByDefault>true</activeByDefault>
+				<activeByDefault>false</activeByDefault>
 			</activation>
 			<build>
 				<plugins>
@@ -292,7 +292,7 @@
 		<profile>
 			<id>without-templates-integration-test</id>
 			<activation>
-				<activeByDefault>false</activeByDefault>
+				<activeByDefault>true</activeByDefault>
 			</activation>
 			<build>
 				<plugins>


### PR DESCRIPTION
it allows to not have to provide specific parameters on new PSI Jenkins


another possibility is to use an environment variable to activate profiles. it might be useful for PR jobs but maybe better to wait to be sure that it is required before using environment variables
