### PR TITLE
FUSETOOLS-3442 - Migrate from tycho-source-feature-plugin to

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,14 +198,13 @@
 
 			<!-- needed for building the source features -->
 			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-source-plugin</artifactId>
 		       <executions>
 		          <execution>
-		            <phase>package</phase>
-		            <id>source-feature</id>
+		            <id>feature-source</id>
 		            <goals>
-		              <goal>source-feature</goal>
+		              <goal>feature-source</goal>
 		            </goals>
 		            <configuration>
 		              <excludes>
@@ -219,8 +218,16 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-p2-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-p2-metadata</id>
+						<phase>package</phase>
+						<goals>
+							<goal>p2-metadata</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
-
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
tycho-source-plugin

as recommended after migrated to Tycho 2.2:
[WARNING] Mojo tycho-source-feature-plugin:source-feature is replaced by
the tycho-source-plugin:feature-source which offers equivalent and even
enhanced functionality

currently failing with:

```
[ERROR] Cannot resolve project dependencies:
[ERROR]   Software being installed: org.fusesource.ide.updatesite raw:11.10.0.'SNAPSHOT'/format(n[.n=0;[.n=0;[-S]]]):11.10.0-SNAPSHOT
[ERROR]   Missing requirement: org.fusesource.ide.updatesite raw:11.10.0.'SNAPSHOT'/format(n[.n=0;[.n=0;[-S]]]):11.10.0-SNAPSHOT requires 'org.eclipse.equinox.p2.iu; org.fusesource.ide.camel.editor.feature.source.feature.group 0.0.0' but it could not be found
[ERROR] 
```