### PR TITLE
JBIDE-27598 - remove locus jaxb-xjc dependency

### DIFF
--- a/transformation/tests/org.jboss.tools.fuse.transformation.core.tests.integration/META-INF/MANIFEST.MF
+++ b/transformation/tests/org.jboss.tools.fuse.transformation.core.tests.integration/META-INF/MANIFEST.MF
@@ -13,7 +13,6 @@ Require-Bundle: org.junit;bundle-version="4.12.0",
  org.fusesource.ide.camel.model.service.core,
  org.fusesource.ide.camel.model.service.impl,
  org.jboss.tools.locus.jsonschema2pojo.jsonschema2pojo-core;bundle-version="0.4.13",
- org.jboss.tools.locus.jaxb-xjc,
  org.eclipse.core.runtime;bundle-version="3.11.1",
  org.eclipse.ui.workbench,
  org.jboss.tools.common.jaxb;resolution:=optional


### PR DESCRIPTION
since work on java 11 compatibility, the jaxb dependency is provided by
org.jboss.tools.common.jaxb

cc @sbouchet 