### PR TITLE
FUSETOOLS-3461 - delete invalid MANIFEST.MF on new places

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/util/BasicProjectCreatorRunnable.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/util/BasicProjectCreatorRunnable.java
@@ -164,14 +164,19 @@ public abstract class BasicProjectCreatorRunnable implements IRunnableWithProgre
 	
 	protected void doAdditionalProjectConfiguration(IProject prj, IProgressMonitor monitor) {
 		// delete invalid MANIFEST files
-		IResource rs = prj.findMember("src/META-INF/"); //$NON-NLS-1$
+		safeDelete(prj, monitor, "src/META-INF/");
+		safeDelete(prj, monitor, "src/main/java/META-INF/");
+	}
+
+	private void safeDelete(IProject prj, IProgressMonitor monitor, String path) {
+		IResource rs = prj.findMember(path); //$NON-NLS-1$
 		if (rs != null && rs.exists()) {
 			try {
 				rs.delete(true, monitor);
 			} catch (CoreException ex) {
 				ProjectTemplatesActivator.pluginLog().logError(ex);
 			}
-		}		
+		}
 	}
 
 	protected boolean requiresFuseIntegrationPerspective() {


### PR DESCRIPTION
an invalid META-INF/MANIFEST.MF is generated by jst.utility facet. A
workaround was previously provided in Fuse Tooling code to delete the
invalid generated META-INF folder. Starting with Eclipse 2021-03, the
default folder to generated this file has been moved from src to
src/main/java. So added this folder to be deleted to have it working
both in previous version of Eclipse and newer version.

it was detected by test
org.fusesource.ide.projecttemplates.tests.integration.wizards.FuseIntegrationProjectCreatorRunnableForOSESringBootIT.additionalChecks(IProject)

it is fixing regression after Target platform upgrade to Eclipse 2021-03