### PR TITLE
Fusetools 3481 use specific camel xsd versions

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse6/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse6/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,7 +23,7 @@
 <blueprint 	xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
     		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     		xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              
-    		  					http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+    		  					http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint-2.17.7.xsd">
     <!--
       The namespace for the camelContext element in Blueprint is 'https://camel.apache.org/schema/blueprint'. Additionally,
       we can also define namespace prefixes we want to use them in the XPath expressions in our CBR.

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7.1/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7.1/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,7 +23,7 @@
 <blueprint 	xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
     		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     		xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              
-    		  					http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+    		  					http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint-2.21.5.xsd">
     <!--
       The namespace for the camelContext element in Blueprint is 'https://camel.apache.org/schema/blueprint'. Additionally,
       we can also define namespace prefixes we want to use them in the XPath expressions in our CBR.

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7.6/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7.6/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,7 +23,7 @@
 <blueprint 	xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
     		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     		xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              
-    		  					http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+    		  					http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint-2.23.3.xsd">
     <!--
       The namespace for the camelContext element in Blueprint is 'https://camel.apache.org/schema/blueprint'. Additionally,
       we can also define namespace prefixes we want to use them in the XPath expressions in our CBR.

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,7 +23,7 @@
 <blueprint 	xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
     		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     		xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              
-    		  					http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+    		  					http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint-2.21.5.xsd">
     <!--
       The namespace for the camelContext element in Blueprint is 'https://camel.apache.org/schema/blueprint'. Additionally,
       we can also define namespace prefixes we want to use them in the XPath expressions in our CBR.

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse6/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse6/src/main/resources/META-INF/spring/camel-context.xml
@@ -15,7 +15,7 @@
 -->
 <!-- Configures the Camel Context-->
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.17.7.xsd">
     <camelContext id="_camelContext1" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
         </route>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7.1/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7.1/src/main/resources/META-INF/spring/camel-context.xml
@@ -15,7 +15,7 @@
 -->
 <!-- Configures the Camel Context-->
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.21.5.xsd">
     <camelContext id="_camelContext1" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
         </route>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7.6/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7.6/src/main/resources/META-INF/spring/camel-context.xml
@@ -15,7 +15,7 @@
 -->
 <!-- Configures the Camel Context-->
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.23.3.xsd">
     <camelContext id="_camelContext1" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
         </route>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7/src/main/resources/META-INF/spring/camel-context.xml
@@ -15,7 +15,7 @@
 -->
 <!-- Configures the Camel Context-->
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.21.5.xsd">
     <camelContext id="_camelContext1" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">
         </route>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse6/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse6/src/main/resources/META-INF/spring/camel-context.xml
@@ -16,7 +16,7 @@
 <!-- Configures the Camel Context-->
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:cxf="http://camel.apache.org/schema/cxf"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd        http://camel.apache.org/schema/cxf http://camel.apache.org/schema/cxf/camel-cxf.xsd    ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.17.7.xsd        http://camel.apache.org/schema/cxf https://camel.apache.org/schema/cxf/camel-cxf-2.17.7-spring.xsd   ">
     <cxf:cxfEndpoint address="http://localhost:9292/cxf/report"
         id="reportEndpoint" serviceClass="com.mycompany.camel.cxf.code.first.spring.incident.IncidentService"/>
     <bean

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7.1/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7.1/src/main/resources/META-INF/spring/camel-context.xml
@@ -16,7 +16,7 @@
 <!-- Configures the Camel Context-->
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:cxf="http://camel.apache.org/schema/cxf"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd        http://camel.apache.org/schema/cxf http://camel.apache.org/schema/cxf/camel-cxf.xsd    ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.21.5.xsd        http://camel.apache.org/schema/cxf http://camel.apache.org/schema/cxf/camel-cxf.xsd    ">
     <cxf:cxfEndpoint address="http://localhost:9292/cxf/report"
         id="reportEndpoint" serviceClass="com.mycompany.camel.cxf.code.first.spring.incident.IncidentService"/>
     <bean

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7.6/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7.6/src/main/resources/META-INF/spring/camel-context.xml
@@ -16,7 +16,7 @@
 <!-- Configures the Camel Context-->
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:cxf="http://camel.apache.org/schema/cxf"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd        http://camel.apache.org/schema/cxf http://camel.apache.org/schema/cxf/camel-cxf.xsd    ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.23.3.xsd        http://camel.apache.org/schema/cxf http://camel.apache.org/schema/cxf/camel-cxf.xsd    ">
     <cxf:cxfEndpoint address="http://localhost:9292/cxf/report"
         id="reportEndpoint" serviceClass="com.mycompany.camel.cxf.code.first.spring.incident.IncidentService"/>
     <bean

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7/src/main/resources/META-INF/spring/camel-context.xml
@@ -16,7 +16,7 @@
 <!-- Configures the Camel Context-->
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:cxf="http://camel.apache.org/schema/cxf"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd        http://camel.apache.org/schema/cxf http://camel.apache.org/schema/cxf/camel-cxf.xsd    ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.21.5.xsd        http://camel.apache.org/schema/cxf http://camel.apache.org/schema/cxf/camel-cxf.xsd    ">
     <cxf:cxfEndpoint address="http://localhost:9292/cxf/report"
         id="reportEndpoint" serviceClass="com.mycompany.camel.cxf.code.first.spring.incident.IncidentService"/>
     <bean

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-blueprint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-blueprint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -22,7 +22,7 @@
 -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
     xmlns:cxf="http://camel.apache.org/schema/blueprint/cxf"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="              http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              http://camel.apache.org/schema/blueprint/cxf http://camel.apache.org/schema/blueprint/cxf/camel-cxf.xsd              http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="              http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              http://camel.apache.org/schema/blueprint/cxf http://camel.apache.org/schema/blueprint/cxf/camel-cxf.xsd              http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint-2.23.3.xsd">
     <cxf:cxfEndpoint address="http://localhost:12345/cxf/order" id="orderEndpoint" serviceClass="ws.camel.mycompany.com.OrderEndpoint"/>
     <camelContext id="camelContext-23ffa64c-2727-4e28-b561-2d39d32c5e53"
         xmlns="http://camel.apache.org/schema/blueprint" xmlns:order="http://com.mycompany.camel.ws">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-java/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-java/src/main/resources/META-INF/spring/camel-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:cxf="http://camel.apache.org/schema/cxf"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd        http://camel.apache.org/schema/cxf http://camel.apache.org/schema/cxf/camel-cxf.xsd    ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.23.3.xsd        http://camel.apache.org/schema/cxf http://camel.apache.org/schema/cxf/camel-cxf.xsd    ">
     <bean id="myBuilder" class="com.mycompany.camel.CamelRoute"/>
     <camelContext id="camelContext-c1100b64-c8cb-4fa6-b382-5eea0e303c95" xmlns="http://camel.apache.org/schema/spring">
         <routeBuilder ref="myBuilder" />  

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-spring/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-spring/src/main/resources/META-INF/spring/camel-context.xml
@@ -16,7 +16,7 @@
 <!-- Configures the Camel Context-->
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:cxf="http://camel.apache.org/schema/cxf"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd        http://camel.apache.org/schema/cxf http://camel.apache.org/schema/cxf/camel-cxf.xsd    ">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.23.3.xsd        http://camel.apache.org/schema/cxf http://camel.apache.org/schema/cxf/camel-cxf.xsd    ">
     <cxf:cxfEndpoint address="http://localhost:12345/cxf/order" id="orderEndpoint" serviceClass="ws.camel.mycompany.com.OrderEndpoint"/>
     <camelContext id="_camelContext1"
         xmlns="http://camel.apache.org/schema/spring" xmlns:order="http://com.mycompany.camel.ws">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-spring-fuse6/src/main/webapp/META-INF/jboss-camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-spring-fuse6/src/main/webapp/META-INF/jboss-camel-context.xml
@@ -19,7 +19,7 @@
   #L%
   -->
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.17.7.xsd">
     <bean class="org.test.MyBean" id="helloBean"/>
     <camelContext id="spring-context" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-spring-fuse7.1/src/main/webapp/META-INF/jboss-camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-spring-fuse7.1/src/main/webapp/META-INF/jboss-camel-context.xml
@@ -19,7 +19,7 @@
   #L%
   -->
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.21.5.xsd">
     <bean class="org.test.MyBean" id="helloBean"/>
     <camelContext id="spring-context" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-spring-fuse7.6/src/main/webapp/META-INF/jboss-camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-spring-fuse7.6/src/main/webapp/META-INF/jboss-camel-context.xml
@@ -19,7 +19,7 @@
   #L%
   -->
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.23.3.xsd">
     <bean class="org.test.MyBean" id="helloBean"/>
     <camelContext id="spring-context" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-spring-fuse7.8/src/main/webapp/META-INF/jboss-camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-spring-fuse7.8/src/main/webapp/META-INF/jboss-camel-context.xml
@@ -19,7 +19,7 @@
   #L%
   -->
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.23.3.xsd">
     <bean class="org.test.MyBean" id="helloBean"/>
     <camelContext id="spring-context" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-spring-fuse7/src/main/webapp/META-INF/jboss-camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-spring-fuse7/src/main/webapp/META-INF/jboss-camel-context.xml
@@ -19,7 +19,7 @@
   #L%
   -->
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.21.5.xsd">
     <bean class="org.test.MyBean" id="helloBean"/>
     <camelContext id="spring-context" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-spring-fusefis/src/main/webapp/META-INF/jboss-camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/camel-test-spring-fusefis/src/main/webapp/META-INF/jboss-camel-context.xml
@@ -19,7 +19,7 @@
   #L%
   -->
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.21.5.xsd">
     <bean class="org.test.MyBean" id="helloBean"/>
     <camelContext id="spring-context" xmlns="http://camel.apache.org/schema/spring">
         <route id="_route1">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/medium-fuse-eap/src/main/webapp/META-INF/jboss-camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/eap-wildfly/medium-fuse-eap/src/main/webapp/META-INF/jboss-camel-context.xml
@@ -22,7 +22,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-       http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+       http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.23.3.xsd">
 
     <bean id="helloBean" class="com.mycompany.wildfly.camel.spring.MyBean" />
 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-spring/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-spring/src/main/resources/META-INF/spring/camel-context.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="
         http://camel.apache.org/schema/spring 
-        https://camel.apache.org/schema/spring/camel-spring.xsd
+        https://camel.apache.org/schema/spring/camel-spring-2.17.7.xsd
         http://www.springframework.org/schema/beans 
         https://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/context 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse6/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse6/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,7 +21,7 @@
    and the Camel namespaces.
 -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="              http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="              http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint-2.17.7.xsd">
     <!--
       The namespace for the camelContext element in Blueprint is 'https://camel.apache.org/schema/blueprint'.
 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7.1/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7.1/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,7 +21,7 @@
    and the Camel namespaces.
 -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="              http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="              http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint-2.21.5.xsd">
     <!--
       The namespace for the camelContext element in Blueprint is 'https://camel.apache.org/schema/blueprint'.
 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7.6/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7.6/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,7 +21,7 @@
    and the Camel namespaces.
 -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="              http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="              http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint-2.23.3.xsd">
     <!--
       The namespace for the camelContext element in Blueprint is 'https://camel.apache.org/schema/blueprint'.
 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,7 +21,7 @@
    and the Camel namespaces.
 -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="              http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="              http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              http://camel.apache.org/schema/blueprint https://camel.apache.org/schema/blueprint/camel-blueprint-2.21.5.xsd">
     <!--
       The namespace for the camelContext element in Blueprint is 'https://camel.apache.org/schema/blueprint'.
 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse6/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse6/src/main/resources/META-INF/spring/camel-context.xml
@@ -15,7 +15,7 @@
 -->
 <!-- Configures the Camel Context-->
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.17.7.xsd">
     <camelContext id="cbr-example-context" xmlns="http://camel.apache.org/schema/spring">
         <!--
           When this route is started, it will automatically create the work/cbr/input directory where you can drop the

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7.1/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7.1/src/main/resources/META-INF/spring/camel-context.xml
@@ -15,7 +15,7 @@
 -->
 <!-- Configures the Camel Context-->
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.21.5.xsd">
     <camelContext id="cbr-example-context" xmlns="http://camel.apache.org/schema/spring">
         <!--
           When this route is started, it will automatically create the work/cbr/input directory where you can drop the

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7.6/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7.6/src/main/resources/META-INF/spring/camel-context.xml
@@ -15,7 +15,7 @@
 -->
 <!-- Configures the Camel Context-->
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.23.3.xsd">
     <camelContext id="cbr-example-context" xmlns="http://camel.apache.org/schema/spring">
         <!--
           When this route is started, it will automatically create the work/cbr/input directory where you can drop the

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7/src/main/resources/META-INF/spring/camel-context.xml
@@ -15,7 +15,7 @@
 -->
 <!-- Configures the Camel Context-->
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.21.5.xsd">
     <camelContext id="cbr-example-context" xmlns="http://camel.apache.org/schema/spring">
         <!--
           When this route is started, it will automatically create the work/cbr/input directory where you can drop the

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse6/src/main/resources/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse6/src/main/resources/spring/camel-context.xml
@@ -4,7 +4,7 @@
        xmlns:camel="http://camel.apache.org/schema/spring"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-       http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+       http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring-2.17.7.xsd">
 
   <!-- Define a traditional camel context here -->
   <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse7.1/src/main/resources/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse7.1/src/main/resources/spring/camel-context.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-       http://camel.apache.org/schema/spring       https://camel.apache.org/schema/spring/camel-spring.xsd">
+       http://camel.apache.org/schema/spring       https://camel.apache.org/schema/spring/camel-spring-2.21.5.xsd">
 
     <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
         <route id="simple-route">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse7.6/src/main/resources/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse7.6/src/main/resources/spring/camel-context.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-       http://camel.apache.org/schema/spring       https://camel.apache.org/schema/spring/camel-spring.xsd">
+       http://camel.apache.org/schema/spring       https://camel.apache.org/schema/spring/camel-spring-2.21.5.xsd">
 
     <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
         <route id="simple-route">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse7.7/src/main/resources/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse7.7/src/main/resources/spring/camel-context.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-       http://camel.apache.org/schema/spring       https://camel.apache.org/schema/spring/camel-spring.xsd">
+       http://camel.apache.org/schema/spring       https://camel.apache.org/schema/spring/camel-spring-2.23.3.xsd">
 
     <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
         <route id="simple-route">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse7.8/src/main/resources/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse7.8/src/main/resources/spring/camel-context.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-       http://camel.apache.org/schema/spring       https://camel.apache.org/schema/spring/camel-spring.xsd">
+       http://camel.apache.org/schema/spring       https://camel.apache.org/schema/spring/camel-spring-2.23.3.xsd">
 
     <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
         <route id="simple-route">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse7/src/main/resources/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse7/src/main/resources/spring/camel-context.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-       http://camel.apache.org/schema/spring       https://camel.apache.org/schema/spring/camel-spring.xsd">
+       http://camel.apache.org/schema/spring       https://camel.apache.org/schema/spring/camel-spring-2.21.5.xsd">
 
     <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
         <route id="simple-route">


### PR DESCRIPTION

use specific xsd versions:
- 2.17.7 xsd for Fuse 6 templates
- 2.21.5 for Fuse 7.0+ and 7.6-
- 2.23.3 for Fuse 7.7+

it avoids to have "latest" to be picked that corresponds to Camel 3.x and which no whave incompatible changes