### PR TITLE
FUSETOOLS-3504 - use registry.redhat.io for Fuse 7.9

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse7.9/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot-fuse7.9/pom.xml
@@ -91,7 +91,7 @@
         <profile>
             <id>openshift</id>
             <properties>
-                <jkube.generator.from>registry.access.redhat.com/fuse7/fuse-java-openshift-rhel8:${docker.image.version}</jkube.generator.from>
+                <jkube.generator.from>registry.redhat.io/fuse7/fuse-java-openshift-rhel8:${docker.image.version}</jkube.generator.from>
             </properties>
             <build>
                 <plugins>
@@ -148,7 +148,7 @@
         <profile>
             <id>java11</id>
             <properties>
-                <jkube.generator.from>registry.access.redhat.com/fuse7/fuse-java-openshift-jdk11-rhel8:${docker.image.version}</jkube.generator.from>
+                <jkube.generator.from>registry.redhat.io/fuse7/fuse-java-openshift-jdk11-rhel8:${docker.image.version}</jkube.generator.from>
             </properties>
             <activation>
                 <jdk>[11,)</jdk>


### PR DESCRIPTION
given that anonymous access seems to have been moved from
registry.access.redhat.com to registry.redhat.io

