### PR TITLE
FUSETOOLS-3554 - Fix build with Tycho 2.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,9 +221,10 @@
 				<executions>
 					<execution>
 						<id>attach-p2-metadata</id>
-						<phase>package</phase>
+						<phase>verify</phase>
 						<goals>
 							<goal>p2-metadata</goal>
+							<goal>feature-p2-metadata</goal>
 						</goals>
 					</execution>
 				</executions>


### PR DESCRIPTION
Tycho 2.5.0 is [no more using pack200](https://www.eclipse.org/lists/cross-project-issues-dev/msg18273.html).
Pack200 was generating p2 metadata for source features (for its own internal need)
p2 metadata are required to build update site for some features sources (in our case _org.fusesource.ide.core.feature.source.feature.group_ even if I do not know why exactly)
To still generate these p2 metadata, adding the goal feature-p2-metadata to tycho-p2-plugin.
This metadata must be generated AFTER the source plugin is generated by the tycho-source-plugin. To achieve that, placing the goal of tycho-p2-plugin to the phase after, which is the verify phase.

