### PR TITLE
FUSETOOLS-3567 - Support Fuse 7.10 with java 11

### DIFF
--- a/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/server/subsystems/BaseKarafStartupLaunchConfigurator.java
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/server/subsystems/BaseKarafStartupLaunchConfigurator.java
@@ -247,7 +247,7 @@ public abstract class BaseKarafStartupLaunchConfigurator extends LaunchConfigura
 		return vmArguments.toString();
 	}
 
-	private boolean isJigsawRunning(IVMInstall vm) {
+	protected boolean isJigsawRunning(IVMInstall vm) {
 		return vm instanceof AbstractVMInstall && JavaUtilities.isJigsawRunning(((AbstractVMInstall) vm).getJavaVersion());
 	}
 

--- a/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/server/subsystems/Karaf4xStartupLaunchConfigurator.java
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/server/subsystems/Karaf4xStartupLaunchConfigurator.java
@@ -18,6 +18,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.wst.server.core.IServer;
 import org.fusesource.ide.foundation.core.util.Strings;
+import org.fusesource.ide.server.karaf.core.runtime.IKarafRuntime;
 import org.fusesource.ide.server.karaf.core.util.IKarafToolingConstants;
 
 /**
@@ -43,7 +44,13 @@ public class Karaf4xStartupLaunchConfigurator extends Karaf3xStartupLaunchConfig
 				String libName = lib.getName();
 				IPath p = path.append(libName);
 				if (lib.isFile()) {
-					if (libName.toLowerCase().indexOf("karaf")!=-1 || lib.getPath().toLowerCase().indexOf("boot")!=-1) {
+					if (libName.toLowerCase().indexOf("karaf")!=-1
+							|| lib.getPath().toLowerCase().indexOf("boot")!=-1
+							|| lib.getPath().indexOf("endorsed") != -1) {
+						cp.add(JavaRuntime.newArchiveRuntimeClasspathEntry(p));
+					}
+					if(isJigsawRunning(((IKarafRuntime)runtime.loadAdapter(IKarafRuntime.class, null)).getVM())
+							&& lib.getPath().indexOf("jdk9plus") != -1) {
 						cp.add(JavaRuntime.newArchiveRuntimeClasspathEntry(p));
 					}
 				} else {


### PR DESCRIPTION
the layout of jar folders has been slightly modified. 2 new folders
available endorsed and jdk9plus.

