### PR TITLE
FUSETOOLS-3596 - Upgrade AssertJ to 3.x

### DIFF
--- a/core/tests/org.fusesource.ide.camel.validation.tests/META-INF/MANIFEST.MF
+++ b/core/tests/org.fusesource.ide.camel.validation.tests/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 11.13.0.qualifier
 Fragment-Host: org.fusesource.ide.camel.validation;bundle-version="10.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,
- org.assertj.core,
+ org.assertj,
  org.mockito;bundle-version="2.23.0"
 Bundle-Vendor: %Bundle-Vendor


### PR DESCRIPTION
to the new version available in Target Platform. Old one (2.x) has been
removed

it will allow to fix the master branch

