### PR TITLE
FUSETOOLS-3590 - add kafka to palette by default

### DIFF
--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/ToolBehaviourProvider.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/ToolBehaviourProvider.java
@@ -129,6 +129,7 @@ public class ToolBehaviourProvider extends DefaultToolBehaviorProvider {
 		CONNECTORS_WHITELIST.add("jdbc");
 		CONNECTORS_WHITELIST.add("jgroups");
 		CONNECTORS_WHITELIST.add("jms");
+		CONNECTORS_WHITELIST.add("kafka");
 		CONNECTORS_WHITELIST.add("language");
 		CONNECTORS_WHITELIST.add("linkedin");
 		CONNECTORS_WHITELIST.add("mina2");

--- a/uitests/plugins/org.jboss.tools.fuse.reddeer/src/org/jboss/tools/fuse/reddeer/component/Kafka.java
+++ b/uitests/plugins/org.jboss.tools.fuse.reddeer/src/org/jboss/tools/fuse/reddeer/component/Kafka.java
@@ -1,0 +1,20 @@
+package org.jboss.tools.fuse.reddeer.component;
+
+public class Kafka implements CamelComponent {
+
+	@Override
+	public String getPaletteEntry() {
+		return "Kafka";
+	}
+
+	@Override
+	public String getLabel() {
+		return "kafka:topic";
+	}
+
+	@Override
+	public String getTooltip() {
+		return "Kafka Component";
+	}
+
+}


### PR DESCRIPTION
the component is nowadays used a lot.
not adding a specific icon as it requires in theory to go through
marketing and legal. it is not worthy enough compared to Eclipse Desktop
tooling priority

![kafkaInPaletteByDefault](https://user-images.githubusercontent.com/1105127/148037215-6d5f1389-008a-404c-b3f7-18ceb3306431.gif)

