### PR TITLE
FUSETOOLS2-3665 - fix deployment to Karaf

### DIFF
--- a/editor/plugins/org.fusesource.ide.project/META-INF/MANIFEST.MF
+++ b/editor/plugins/org.fusesource.ide.project/META-INF/MANIFEST.MF
@@ -37,7 +37,8 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.106.0",
  org.fusesource.ide.camel.model.service.core;bundle-version="10.0.0",
  org.fusesource.ide.camel.validation;bundle-version="10.0.0",
  org.fusesource.ide.camel.editor;bundle-version="10.0.0",
- org.eclipse.jst.server.core;bundle-version="1.2.400"
+ org.eclipse.jst.server.core;bundle-version="1.2.400",
+ org.eclipse.m2e.pde.connector;bundle-version="2.0.1"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.fusesource.ide.project.Activator
 Export-Package: org.fusesource.ide.project,

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse6/pom.xml
@@ -143,6 +143,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7.1/pom.xml
@@ -143,6 +143,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7.10.1/pom.xml
@@ -139,6 +139,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7.10/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7.10/pom.xml
@@ -143,6 +143,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7.6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7.6/pom.xml
@@ -143,6 +143,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7/pom.xml
@@ -141,6 +141,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java-fuse6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java-fuse6/pom.xml
@@ -117,6 +117,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java-fuse7.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java-fuse7.1/pom.xml
@@ -116,6 +116,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java-fuse7.10.1/pom.xml
@@ -112,6 +112,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java-fuse7.10/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java-fuse7.10/pom.xml
@@ -116,6 +116,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java-fuse7.6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java-fuse7.6/pom.xml
@@ -116,6 +116,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java-fuse7/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java-fuse7/pom.xml
@@ -117,6 +117,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse6/pom.xml
@@ -135,6 +135,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7.1/pom.xml
@@ -137,6 +137,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7.10.1/pom.xml
@@ -133,6 +133,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7.10/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7.10/pom.xml
@@ -137,6 +137,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7.6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7.6/pom.xml
@@ -137,6 +137,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7/pom.xml
@@ -139,6 +139,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java-fuse6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java-fuse6/pom.xml
@@ -219,6 +219,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java-fuse7.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java-fuse7.1/pom.xml
@@ -213,6 +213,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java-fuse7.10.1/pom.xml
@@ -209,6 +209,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java-fuse7.10/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java-fuse7.10/pom.xml
@@ -213,6 +213,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java-fuse7.6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java-fuse7.6/pom.xml
@@ -213,6 +213,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java-fuse7/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java-fuse7/pom.xml
@@ -213,6 +213,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse6/pom.xml
@@ -248,6 +248,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.camel</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7.1/pom.xml
@@ -233,6 +233,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.jboss.redhat-fuse</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7.10.1/pom.xml
@@ -229,6 +229,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.jboss.redhat-fuse</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7.10/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7.10/pom.xml
@@ -233,6 +233,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.jboss.redhat-fuse</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7.6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7.6/pom.xml
@@ -233,6 +233,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.jboss.redhat-fuse</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7/pom.xml
@@ -234,6 +234,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.camel</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-blueprint/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-blueprint/pom.xml
@@ -255,6 +255,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 
 			<!-- this plugin will use the fabric.* properties to configure its behaviour 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-java/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-java/pom.xml
@@ -246,6 +246,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-spring/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-spring/pom.xml
@@ -247,6 +247,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 
 			<!-- this plugin will use the fabric.* properties to configure its behaviour 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-blueprint/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-blueprint/pom.xml
@@ -144,6 +144,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${maven-bundle-plugin.version}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/pom.xml
@@ -112,6 +112,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-spring/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-spring/pom.xml
@@ -93,6 +93,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${maven-bundle-plugin.version}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse6/pom.xml
@@ -127,6 +127,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7.1/pom.xml
@@ -126,6 +126,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7.10.1/pom.xml
@@ -122,6 +122,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7.10/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7.10/pom.xml
@@ -126,6 +126,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7.6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7.6/pom.xml
@@ -126,6 +126,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7/pom.xml
@@ -127,6 +127,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java-fuse6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java-fuse6/pom.xml
@@ -116,6 +116,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java-fuse7.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java-fuse7.1/pom.xml
@@ -116,6 +116,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java-fuse7.10.1/pom.xml
@@ -112,6 +112,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java-fuse7.10/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java-fuse7.10/pom.xml
@@ -116,6 +116,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java-fuse7.6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java-fuse7.6/pom.xml
@@ -116,6 +116,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java-fuse7/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java-fuse7/pom.xml
@@ -116,6 +116,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse6/pom.xml
@@ -121,6 +121,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7.1/pom.xml
@@ -124,6 +124,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7.10.1/pom.xml
@@ -120,6 +120,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7.10/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7.10/pom.xml
@@ -124,6 +124,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7.6/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7.6/pom.xml
@@ -124,6 +124,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7/pom.xml
@@ -125,6 +125,17 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>${version.maven-bundle-plugin}</version>
 				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>scr-metadata</id>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+						<configuration>
+							<supportIncrementalBuild>true</supportIncrementalBuild>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/editor/tests/org.fusesource.ide.project.tests.integration/src/main/java/org/fusesource/ide/project/DependencyCheckIT.java
+++ b/editor/tests/org.fusesource.ide.project.tests.integration/src/main/java/org/fusesource/ide/project/DependencyCheckIT.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at https://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.fusesource.ide.project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+import org.junit.Test;
+import org.osgi.framework.Constants;
+
+public class DependencyCheckIT {
+	
+	@Test
+	public void testDependencyProvidingM2EConnectorForMavenBundleAvailable() throws Exception {
+		InputStream manifestStream = Activator.class.getResourceAsStream("/META-INF/MANIFEST.MF");
+		Manifest manifest = new Manifest(manifestStream);
+		Attributes mainAttributes = manifest.getMainAttributes();
+		String requireBundles = mainAttributes.getValue(Constants.REQUIRE_BUNDLE);
+		assertThat(requireBundles).contains("org.eclipse.m2e.pde.connector");
+	}
+
+}

--- a/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/projects/bean-blueprint/pom.xml
+++ b/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/projects/bean-blueprint/pom.xml
@@ -130,6 +130,17 @@
           <instructions>
             <Bundle-SymbolicName>hello-blueprint</Bundle-SymbolicName>
             <Bundle-Name>Empty Camel Blueprint Example [hello-blueprint]</Bundle-Name></instructions></configuration>
+          <executions>
+              <execution>
+                <id>scr-metadata</id>
+                <goals>
+                   <goal>manifest</goal>
+                </goals>
+                <configuration>
+                   <supportIncrementalBuild>true</supportIncrementalBuild>
+                </configuration>
+              </execution>
+           </executions>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/projects/bean-spring/pom.xml
+++ b/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/projects/bean-spring/pom.xml
@@ -123,6 +123,17 @@
           <instructions>
             <Bundle-SymbolicName>hello-spring</Bundle-SymbolicName>
             <Bundle-Name>Empty Camel Spring Example [hello-spring]</Bundle-Name></instructions></configuration>
+          <executions>
+              <execution>
+                <id>scr-metadata</id>
+                <goals>
+                   <goal>manifest</goal>
+                </goals>
+                <configuration>
+                   <supportIncrementalBuild>true</supportIncrementalBuild>
+                </configuration>
+              </execution>
+           </executions>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/projects/rest-blueprint/pom.xml
+++ b/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/projects/rest-blueprint/pom.xml
@@ -145,6 +145,17 @@
             <Bundle-Name>Empty Camel Blueprint Example [rest-blueprint]</Bundle-Name>
           </instructions>
         </configuration>
+        <executions>
+              <execution>
+                <id>scr-metadata</id>
+                <goals>
+                   <goal>manifest</goal>
+                </goals>
+                <configuration>
+                   <supportIncrementalBuild>true</supportIncrementalBuild>
+                </configuration>
+              </execution>
+           </executions>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/projects/rest-spring/pom.xml
+++ b/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/projects/rest-spring/pom.xml
@@ -145,6 +145,17 @@
             <Bundle-Name>Empty Camel Spring Example [rest-spring]</Bundle-Name>
           </instructions>
         </configuration>
+        <executions>
+              <execution>
+                <id>scr-metadata</id>
+                <goals>
+                   <goal>manifest</goal>
+                </goals>
+                <configuration>
+                   <supportIncrementalBuild>true</supportIncrementalBuild>
+                </configuration>
+              </execution>
+           </executions>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/projects/test-route-manipulation/pom.xml
+++ b/uitests/tests/org.jboss.tools.fuse.ui.bot.tests/resources/projects/test-route-manipulation/pom.xml
@@ -128,6 +128,17 @@
             <Bundle-Name>Empty Camel Blueprint Example [test-route-manipulation]</Bundle-Name>
           </instructions>
         </configuration>
+        <executions>
+              <execution>
+                <id>scr-metadata</id>
+                <goals>
+                   <goal>manifest</goal>
+                </goals>
+                <configuration>
+                   <supportIncrementalBuild>true</supportIncrementalBuild>
+                </configuration>
+              </execution>
+           </executions>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -144,14 +155,14 @@
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
-      <plugin>
+      <!--plugin>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-maven-plugin</artifactId>
         <version>${camel.version}</version>
         <configuration>
           <useBlueprint>true</useBlueprint>
         </configuration>
-      </plugin>
+      </plugin-->
     </plugins>
   </build>
   <profiles>


### PR DESCRIPTION
- changed only for latest versions of examples to limit things to be tested. Maybe we can live with the regression for older versions as there are workarounds and the JBoss Tools is not part of the support. users can stick with older version of CodeReady Studio for older Fuse version?
- the maven-bundle-plugin on Camel fuse supported version is 3.5.1 https://github.com/jboss-fuse/camel/blob/f96b861d57b660710011110c991a37e272c1186d/parent/pom.xml#L488 but only 5.x contains a fix. So we have not aligned version. In theory, it is affecting only the build and not the runtime so should be fine.
- The m2e connector which was working before was in version 0.8.1 (sonatype.tycho), it was overriding the maven-bundle-plugin embedded m2e connector configuration. Unfortunately, this sonatype.tycho has been abandoned and is not working with latest Eclipse 2022-09 (incompatible with M2e 2.x)
- note that an extra configuration must be provided to have incremental build generating the Manifest.mf correctly.

