### PR TITLE
FUSETOOLS-3665 - use newer maven-bundle-plugin

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-blueprint-fuse7.10.1/pom.xml
@@ -23,7 +23,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<version.maven-bundle-plugin>3.2.0</version.maven-bundle-plugin>
+		<version.maven-bundle-plugin>5.1.8</version.maven-bundle-plugin>
 
 		<!-- the version of the Red Hat Fuse BOM, defining all the dependency versions -->
 		<jboss.fuse.bom.version>%%%PLACEHOLDER_BOMVERSION%%%</jboss.fuse.bom.version>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-java-fuse7.10.1/pom.xml
@@ -17,7 +17,7 @@
 		</license>
 	</licenses>
 	<properties>
-		<version.maven-bundle-plugin>3.2.0</version.maven-bundle-plugin>
+		<version.maven-bundle-plugin>5.1.8</version.maven-bundle-plugin>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<jboss.fuse.bom.version>%%%PLACEHOLDER_BOMVERSION%%%</jboss.fuse.bom.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/blank/blank-spring-fuse7.10.1/pom.xml
@@ -22,7 +22,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<version.maven-bundle-plugin>3.2.0</version.maven-bundle-plugin>
+		<version.maven-bundle-plugin>5.1.8</version.maven-bundle-plugin>
 
 		<!-- the version of the Red Hat Fuse BOM, defining all the dependency versions -->
 		<jboss.fuse.bom.version>%%%PLACEHOLDER_BOMVERSION%%%</jboss.fuse.bom.version>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java-fuse7.10.1/pom.xml
@@ -17,7 +17,7 @@
 		</license>
 	</licenses>
 	<properties>
-		<version.maven-bundle-plugin>3.2.0</version.maven-bundle-plugin>
+		<version.maven-bundle-plugin>5.1.8</version.maven-bundle-plugin>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<jboss.fuse.bom.version>%%%PLACEHOLDER_BOMVERSION%%%</jboss.fuse.bom.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring-fuse7.10.1/pom.xml
@@ -21,7 +21,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<version.maven-bundle-plugin>3.2.0</version.maven-bundle-plugin>
+		<version.maven-bundle-plugin>5.1.8</version.maven-bundle-plugin>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-blueprint/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-blueprint/pom.xml
@@ -18,7 +18,7 @@
 	</licenses>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<version.maven-bundle-plugin>3.2.0</version.maven-bundle-plugin>
+		<version.maven-bundle-plugin>5.1.8</version.maven-bundle-plugin>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<version.maven-surefire-plugin>2.19.1</version.maven-surefire-plugin>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-java/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-java/pom.xml
@@ -17,7 +17,7 @@
   </licenses>
 	<properties>
 		<camel.version>2.15.1.redhat-621084</camel.version>
-		<version.maven-bundle-plugin>3.2.0</version.maven-bundle-plugin>
+		<version.maven-bundle-plugin>5.1.8</version.maven-bundle-plugin>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<jboss.fuse.bom.version>6.2.1.redhat-084</jboss.fuse.bom.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-spring/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-contract-first/medium-fuse-cxf-contract-first-spring/pom.xml
@@ -17,7 +17,7 @@
 	</licenses>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<version.maven-bundle-plugin>3.2.0</version.maven-bundle-plugin>
+		<version.maven-bundle-plugin>5.1.8</version.maven-bundle-plugin>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<version.maven-surefire-plugin>2.19.1</version.maven-surefire-plugin>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint-fuse7.10.1/pom.xml
@@ -18,7 +18,7 @@
 	</licenses>
 	<properties>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<version.maven-bundle-plugin>3.2.0</version.maven-bundle-plugin>
+		<version.maven-bundle-plugin>5.1.8</version.maven-bundle-plugin>
 		<fuse.version>%%%PLACEHOLDER_BOMVERSION%%%</fuse.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java-fuse7.10.1/pom.xml
@@ -18,7 +18,7 @@
 	</licenses>
 	<properties>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<version.maven-bundle-plugin>3.2.0</version.maven-bundle-plugin>
+		<version.maven-bundle-plugin>5.1.8</version.maven-bundle-plugin>
 		<jboss.fuse.bom.version>%%%PLACEHOLDER_BOMVERSION%%%</jboss.fuse.bom.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7.10.1/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring-fuse7.10.1/pom.xml
@@ -18,7 +18,7 @@
 	</licenses>
 	<properties>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<version.maven-bundle-plugin>3.2.0</version.maven-bundle-plugin>
+		<version.maven-bundle-plugin>5.1.8</version.maven-bundle-plugin>
 		<fuse.version>%%%PLACEHOLDER_BOMVERSION%%%</fuse.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
to workaround regression in Eclipse m2e connector. The version used is then not a strictly match with what is supported at runtime but it shouldn't cause a problem.
Workarounded only for latest versions

