### PR TITLE
Upgrade jacoco to support java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
 					<plugin>
 						<groupId>org.jacoco</groupId>
 						<artifactId>jacoco-maven-plugin</artifactId>
-						<version>0.8.3</version>
+						<version>0.8.9</version>
 						<configuration>
 							<append>true</append>
 							<includes>


### PR DESCRIPTION
which is required as runtime

it avoids this kind of error in log:

```
Caused by: java.io.IOException: Error while instrumenting org/fusesource/ide/launcher/debug/model/CamelDebugFacade$MockitoMock$FbAv5SJE$auxiliary$hqoeDniq.
	at org.jacoco.agent.rt.internal_1f1cc91.core.instr.Instrumenter.instrumentError(Instrumenter.java:170)
	at org.jacoco.agent.rt.internal_1f1cc91.core.instr.Instrumenter.instrument(Instrumenter.java:120)
	at org.jacoco.agent.rt.internal_1f1cc91.CoverageTransformer.transform(CoverageTransformer.java:91)
	... 57 more
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 61
	at org.jacoco.agent.rt.internal_1f1cc91.asm.ClassReader.<init>(ClassReader.java:184)
	at org.jacoco.agent.rt.internal_1f1cc91.asm.ClassReader.<init>(ClassReader.java:166)
	at org.jacoco.agent.rt.internal_1f1cc91.asm.ClassReader.<init>(ClassReader.java:152)
	at org.jacoco.agent.rt.internal_1f1cc91.core.internal.instr.InstrSupport.classReaderFor(InstrSupport.java:247)
	at org.jacoco.agent.rt.internal_1f1cc91.core.instr.Instrumenter.instrument(Instrumenter.java:86)
	at org.jacoco.agent.rt.internal_1f1cc91.core.instr.Instrumenter.instrument(Instrumenter.java:118)
	... 58 more
```